### PR TITLE
 Replace toggle + add buttons with dedicated whitelist/graylist buttons. 

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -5,13 +5,13 @@
   },
 
   "extensionDescription": {
-    "message": "Control Your Cookies! Auto Delete Unused Cookies From your Closed Tabs While Keeping The Ones You Want.",
-    "description": "Control Your Cookies! Auto Delete Unused Cookies From your Closed Tabs While Keeping The Ones You Want."
+    "message": "Control your cookies! Auto-delete unused cookies from your closed tabs while keeping the ones you want.",
+    "description": "Control your cookies! Auto-delete unused cookies from your closed tabs while keeping the ones you want."
   },
 
   "notificationTitle": {
-    "message": "Cookie AutoDelete: Cookies were Deleted!",
-    "description": "Cookie AutoDelete: Cookies were Deleted!"
+    "message": "Cookie AutoDelete: Cookies were deleted!",
+    "description": "Cookie AutoDelete: Cookies were deleted!"
   },
 
   "notificationContent": {
@@ -60,13 +60,13 @@
   },
 
   "switchToGreyListText": {
-    "message": "Clean on Browser Restart (GreyList)",
-    "description": "Clean on Browser Restart (GreyList)"
+    "message": "Clean on Browser Restart (Greylist)",
+    "description": "Clean on Browser Restart (Greylist)"
   },
 
   "switchToWhiteListText": {
-    "message": "Never Clean (WhiteList)",
-    "description": "Never Clean (WhiteList)"
+    "message": "Never Clean (Whitelist)",
+    "description": "Never Clean (Whitelist)"
   },
 
   "welcomeText": {
@@ -105,8 +105,8 @@
   },
 
   "reviewLinkMessage": {
-    "message": "Thanks for trying out Cookie AutoDelete. If you liked it, then please give a Review.",
-    "description": "Thanks for trying out Cookie AutoDelete. If you liked it, then please give a Review."
+    "message": "Thanks for trying out Cookie AutoDelete. If you liked it, then please give a review.",
+    "description": "Thanks for trying out Cookie AutoDelete. If you liked it, then please give a review."
   },
 
   "releaseNotesText": {
@@ -140,13 +140,13 @@
   },
 
   "notifyCookieCleanUpText": {
-    "message": "Show Notification After Cookie CleanUp",
-    "description": "Show Notification After Cookie CleanUp"
+    "message": "Show Notification After Cookie Cleanup",
+    "description": "Show Notification After Cookie Cleanup"
   },
 
   "cookieCleanUpOnStartText": {
-    "message": "Clean Cookies from Open Tabs on StartUp",
-    "description": "Clean Cookies from Open Tabs on StartUp"
+    "message": "Clean Cookies from Open Tabs on Startup",
+    "description": "Clean Cookies from Open Tabs on Startup"
   },
 
   "enableGlobalSubdomainText": {
@@ -165,23 +165,23 @@
   },
 
   "whiteListWordText": {
-    "message": "WhiteList",
-    "description": "WhiteList"
+    "message": "Whitelist",
+    "description": "Whitelist"
   },
 
   "greyListWordText": {
-    "message": "GreyList",
-    "description": "GreyList"
+    "message": "Greylist",
+    "description": "Greylist"
   },
 
   "toWhiteListText": {
-    "message": "To WhiteList",
+    "message": "To Whitelist",
     "description": "To WhiteList"
   },
 
   "toGreyListText": {
-    "message": "To GreyList",
-    "description": "To GreyList"
+    "message": "To Greylist",
+    "description": "To Greylist"
   },
 
   "clearURLText": {
@@ -220,8 +220,8 @@
   },
 
   "domainExpressionsText": {
-    "message": "Domain Expressions",
-    "description": "Domain Expressions"
+    "message": "Domain Expression",
+    "description": "Domain Expression"
   },
 
   "matchedDomainExpressionText": {

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -175,13 +175,13 @@
   },
 
   "toWhiteListText": {
-    "message": "To Whitelist",
-    "description": "To WhiteList"
+    "message": "Add to Whitelist",
+    "description": "Add to WhiteList"
   },
 
   "toGreyListText": {
-    "message": "To Greylist",
-    "description": "To Greylist"
+    "message": "Add to Greylist",
+    "description": "Add to Greylist"
   },
 
   "clearURLText": {
@@ -239,9 +239,9 @@
     "description": "List Type"
   },
 
-  "enterDomainText": {
-    "message": "Enter Domain",
-    "description": "Enter Domain"
+  "domainPlaceholderText": {
+    "message": "example.com, www.example.com, *.example.com",
+    "description": "Domain Expression"
   }
 
 

--- a/src/ui/settings/components/Expressions.js
+++ b/src/ui/settings/components/Expressions.js
@@ -37,8 +37,7 @@ class Expressions extends React.Component {
 			expressionInput: "",
 			error: "",
 			storeId: "default",
-			contextualIdentitiesObjects: [],
-			listType: "WHITE"
+			contextualIdentitiesObjects: []
 		};
 	}
 
@@ -87,13 +86,6 @@ class Expressions extends React.Component {
 		});
 	}
 
-	// Switch the list type for adding a expression
-	switchListType() {
-		this.setState({
-			listType: this.state.listType === "WHITE" ? "GREY" : "WHITE"
-		});
-	}
-
 	async componentDidMount() {
 		if (this.props.contextualIdentities) {
 			const contextualIdentitiesObjects = await browser.contextualIdentities.query({});
@@ -110,14 +102,13 @@ class Expressions extends React.Component {
 			contextualIdentities
 		} = this.props;
 		const {
-			error, contextualIdentitiesObjects, storeId, listType
+			error, contextualIdentitiesObjects, storeId
 		} = this.state;
 		return (
 			<div style={style}>
 				<h1>{browser.i18n.getMessage("whiteListText")}</h1>
 
 				<div className="row md-form">
-					<label htmlFor="form1" className="">{`${browser.i18n.getMessage("enterDomainText")}:`}</label>
 					<input
 						style={{
 							display: "inline", width: "100%"
@@ -126,10 +117,13 @@ class Expressions extends React.Component {
 						onChange={(e) => this.setState({
 							expressionInput: e.target.value
 						})}
+						placeholder={browser.i18n.getMessage("domainPlaceholderText")}
 						onKeyPress={(e) => {
 							if (e.key === "Enter") {
 								this.addExpressionByInput({
-									expression: this.state.expressionInput, storeId, listType
+									expression: this.state.expressionInput,
+									storeId,
+									listType: "WHITE"
 								});
 							}
 						}}
@@ -160,16 +154,21 @@ class Expressions extends React.Component {
 					<span style={{
 						padding: "5px 5px"
 					}} className="pull-right">
-						<button onClick={() => this.switchListType()} className="btn btn-info">
-							{`${listType === "WHITE" ? browser.i18n.getMessage("toWhiteListText") : browser.i18n.getMessage("toGreyListText")}`}
+						<button className="btn btn-secondary" onClick={() => this.addExpressionByInput({
+							expression: this.state.expressionInput,
+							storeId,
+							listType: "GREY"
+						})}>
+							{browser.i18n.getMessage("toGreyListText")}
 						</button>
-
 						<button style={{
 							marginLeft: "5px"
 						}} className="btn btn-primary" onClick={() => this.addExpressionByInput({
-							expression: this.state.expressionInput, storeId, listType
+							expression: this.state.expressionInput,
+							storeId,
+							listType: "WHITE"
 						})}>
-							<i className="fa fa-plus-square" aria-hidden="true"></i>
+							{browser.i18n.getMessage("toWhiteListText")}
 						</button>
 					</span>
 				</div>


### PR DESCRIPTION
This improves the UI in a couple ways: now there is only one click to add either
to the whitelist/graylist and there is no non-obvious toggle button to switch states.
Furthermore, the "primary" (whitelist) button is more visually emphasized and is the
default action when you press Enter.

This also removes the redundant header on the input and replaces it with an inline
placeholder to lead by example.

Note that this PR is built on top of #159 so that should merge first.

![image](https://user-images.githubusercontent.com/2101409/30885282-79993c62-a2c7-11e7-84d1-9b6364abc5e0.png)
