### PR TITLE
Add link from "About" to documentation

### DIFF
--- a/src/ui/settings/components/About.js
+++ b/src/ui/settings/components/About.js
@@ -28,6 +28,8 @@ const About = (props) => {
 				<li><a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors">GitHub Contributors</a></li>
 				<li><a href="https://crowdin.com/project/cookie-autodelete">Crowdin Contributors</a></li>
 			</ul>
+			<br/><br/>
+			<a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/Documentation/"><span>{`${browser.i18n.getMessage("documentationText", ["Documentation"])}`}</span> </a>
 		</div>
 	);
 };


### PR DESCRIPTION
A link to the documentation doesn't seem to be available at all in the extension itself.