### PR TITLE
Added dynamic timestamp to export filename (Resolves #216)

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -200,6 +200,11 @@
     "description": "Export Expressions"
   },
 
+  "exportURLSTitle": {
+    "message": "A timestamp will be appended to the filename on export.\nHaving trouble downloading?  Right-Click this button and click 'Save Link As...' to download.",
+    "description": "A timestamp will be appended to the filename on export.\nHaving trouble downloading?  Right-Click this button and click 'Save Link As...' to download."
+  },
+
   "importURLSText": {
     "message": "Import Expressions",
     "description": "Import Expressions"

--- a/src/ui/popup/App.js
+++ b/src/ui/popup/App.js
@@ -130,7 +130,7 @@ class App extends Component {
 
 						<div
 							className="btn-group"
-							ref={(e) => { this.cleanButtonContainerRef = e; }}
+							ref={(e) => {this.cleanButtonContainerRef = e;}}
 							style={{
 								margin: "0 4px"
 							}}
@@ -233,7 +233,9 @@ class App extends Component {
 						<div style={{
 							flex: 1
 						}}>{hostname}</div>
-						<div className="btn-group" style={{ marginLeft: "8px" }}>
+						<div className="btn-group" style={{
+							marginLeft: "8px"
+						}}>
 							<IconButton
 								className="btn-secondary"
 								onClick={() => {onNewExpression({

--- a/src/ui/settings/components/Expressions.js
+++ b/src/ui/settings/components/Expressions.js
@@ -90,6 +90,16 @@ class Expressions extends React.Component {
 		}
 	}
 
+	// Dynamically generate and append timestamp to download filename
+	exportAppendTimestamp() {
+		// We take into account the timezone offset since using Date.toISOString() returns in UTC/GMT.
+		document.getElementById("export_link").setAttribute("download", `Cookie_AutoDelete_2.X.X_Expressions_${new Date(new Date().getTime() - new Date().getTimezoneOffset() * 60000)
+			.toISOString()
+			.slice(0, -5)
+			.replace("T", "_")
+			.replace(/:/g, ".")}.json`);
+	}
+
 	render() {
 		const {
 			style,
@@ -136,11 +146,16 @@ class Expressions extends React.Component {
 					}}>
 						<IconButton
 							tag="a"
+							id="export_link"
 							className="btn-primary"
 							iconName="download"
 							href={`data:text/plain;charset=utf-8,${encodeURIComponent(JSON.stringify(this.props.lists, null, "  "))}`}
 							download="Cookie_AutoDelete_2.X.X_Expressions.json"
 							role="button"
+							target="_blank"
+							onClick={() => this.exportAppendTimestamp()}
+							onContextMenu={() => this.exportAppendTimestamp()}
+							title={browser.i18n.getMessage("exportURLSTitle")}
 							text={browser.i18n.getMessage("exportURLSText")}
 						/>
 

--- a/src/ui/settings/components/Expressions.js
+++ b/src/ui/settings/components/Expressions.js
@@ -91,9 +91,9 @@ class Expressions extends React.Component {
 	}
 
 	// Dynamically generate and append timestamp to download filename
-	exportAppendTimestamp() {
+	exportAppendTimestamp(element) {
 		// We take into account the timezone offset since using Date.toISOString() returns in UTC/GMT.
-		document.getElementById("export_link").setAttribute("download", `Cookie_AutoDelete_2.X.X_Expressions_${new Date(new Date().getTime() - new Date().getTimezoneOffset() * 60000)
+		element.setAttribute("download", `Cookie_AutoDelete_2.X.X_Expressions_${new Date(new Date().getTime() - new Date().getTimezoneOffset() * 60000)
 			.toISOString()
 			.slice(0, -5)
 			.replace("T", "_")
@@ -146,15 +146,14 @@ class Expressions extends React.Component {
 					}}>
 						<IconButton
 							tag="a"
-							id="export_link"
 							className="btn-primary"
 							iconName="download"
 							href={`data:text/plain;charset=utf-8,${encodeURIComponent(JSON.stringify(this.props.lists, null, "  "))}`}
 							download="Cookie_AutoDelete_2.X.X_Expressions.json"
 							role="button"
 							target="_blank"
-							onClick={() => this.exportAppendTimestamp()}
-							onContextMenu={() => this.exportAppendTimestamp()}
+							onClick={(d) => this.exportAppendTimestamp(d.target)}
+							onContextMenu={(d) => this.exportAppendTimestamp(d.target)}
 							title={browser.i18n.getMessage("exportURLSTitle")}
 							text={browser.i18n.getMessage("exportURLSText")}
 						/>


### PR DESCRIPTION
My Implementation for feature request #216 for appending timestamp to backup filename.

This will append the timestamp to the filename on either left or right click.

Sample Exported Filename:
![Sample Exported Filename](https://user-images.githubusercontent.com/6724477/34086779-79ce6f3c-e353-11e7-8135-7639b752b081.png)


Added some hints are given upon mouse-over of 'Export Expressions' Button.

Tested on Fedora 27 on Firefox 57.0.1 and Chrome 63.

Comments/Feedback/Critique/Suggestions for other improvements are welcomed.

Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>