### PR TITLE
Added Focus to input field on Edit

### DIFF
--- a/src/ui/common_components/ExpressionTable.js
+++ b/src/ui/common_components/ExpressionTable.js
@@ -38,6 +38,18 @@ class ExpressionTable extends React.Component {
 		});
 	}
 
+	componentDidUpdate(prevProps, prevState) {
+		if (this.editInput !== null && this.state.editMode === true && document.activeElement !== document.getElementById("formText")) {
+			this.editInput.focus();
+		}
+	}
+
+	moveCaretToEnd(e) {
+		let tempValue = e.target.value;
+		e.target.value = "";
+		e.target.value = tempValue;
+	}
+
 	clearEdit() {
 		this.setState(EMPTY_STATE);
 	}
@@ -98,9 +110,9 @@ class ExpressionTable extends React.Component {
 								{
 									editMode & id === expression.id ?
 										<td className="editableExpression">
-											<input className="form-control" value={expressionInput} onChange={(e) => this.setState({
+											<input ref={(c) => {this.editInput = c;}} className="form-control" value={expressionInput} onFocus={this.moveCaretToEnd} onChange={(e) => this.setState({
 												expressionInput: e.target.value
-											})} type="text" style={{
+											})} type="text" autoFocus="autofocus" style={{
 												display: "inline-block", verticalAlign: "middle", margin: 0, width: "calc(100% - 70px)"
 											}} />
 											<IconButton

--- a/src/ui/popup/App.js
+++ b/src/ui/popup/App.js
@@ -130,7 +130,7 @@ class App extends Component {
 
 						<div
 							className="btn-group"
-							ref={(e) => { this.cleanButtonContainerRef = e; }}
+							ref={(e) => {this.cleanButtonContainerRef = e;}}
 							style={{
 								margin: "0 4px"
 							}}
@@ -233,7 +233,9 @@ class App extends Component {
 						<div style={{
 							flex: 1
 						}}>{hostname}</div>
-						<div className="btn-group" style={{ marginLeft: "8px" }}>
+						<div className="btn-group" style={{
+							marginLeft: "8px"
+						}}>
 							<IconButton
 								className="btn-secondary"
 								onClick={() => {onNewExpression({


### PR DESCRIPTION
My implementation for feature request/bugfix of #234.

`autofocus` attribute is new in HTML5, so a workaround was also implemented for older HTML versions within `componentDidUpdate()`.

Since `componentDidUpdate()` runs after each component update, thus checks were added to check if we're actually editing a domain expression, and focuses on that edit input.  If the new expression input is currently in focus and an edit input is already shown, it won't focus onto the edit input.

Additionally, the caret will be at the end of the current value whenever the edit input is focused.  Originally without the `onFocus` attribute and the `moveCaretToEnd` function, the caret would appear in the beginning of the edit text.  If that should be intended result, simply remove the `onFocus` attribute and `moveCaretToEnd` function.

Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>