### PR TITLE
Fixed CSS Settings Panel Covering Settings ( Resolves #286 )

### DIFF
--- a/extension/settings/side-menu.css
+++ b/extension/settings/side-menu.css
@@ -241,7 +241,7 @@ Hides the menu at `48em`, but modify this based on your app's needs
   }
 }
 
-@media (max-width: 48em) {
+@media (max-width: 1300px) {
   /* Only apply this when the window is small. Otherwise, the following
      case results in extra padding on the left:
          * Make the window small
@@ -251,6 +251,6 @@ Hides the menu at `48em`, but modify this based on your app's needs
 
   #layout.active {
     position: relative;
-    left: 150px;
+    margin-left: 150px;
   }
 }

--- a/src/ui/popup/App.js
+++ b/src/ui/popup/App.js
@@ -130,7 +130,7 @@ class App extends Component {
 
 						<div
 							className="btn-group"
-							ref={(e) => { this.cleanButtonContainerRef = e; }}
+							ref={(e) => {this.cleanButtonContainerRef = e;}}
 							style={{
 								margin: "0 4px"
 							}}
@@ -233,7 +233,9 @@ class App extends Component {
 						<div style={{
 							flex: 1
 						}}>{hostname}</div>
-						<div className="btn-group" style={{ marginLeft: "8px" }}>
+						<div className="btn-group" style={{
+							marginLeft: "8px"
+						}}>
 							<IconButton
 								className="btn-secondary"
 								onClick={() => {onNewExpression({


### PR DESCRIPTION
My Implementation to Feature Request/Bugfix of #286.

This will stop the small nav sidebar from covering up part of the settings below 1300px, since after 1300px the menu is fixed.

Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>