### PR TITLE
Close popup when opening settings page

### DIFF
--- a/src/ui/popup/App.js
+++ b/src/ui/popup/App.js
@@ -235,9 +235,12 @@ class App extends Component {
 							style={{
 								margin: "0 4px"
 							}}
-							onClick={() => browser.tabs.create({
-								url: "/settings/settings.html#tabSettings"
-							})}
+							onClick={() => {
+								browser.tabs.create({
+									url: "/settings/settings.html#tabSettings"
+								});
+								window.close();
+							}}
 							title={browser.i18n.getMessage("preferencesText")}
 							text={browser.i18n.getMessage("preferencesText")}
 						/>


### PR DESCRIPTION
This change makes the popup automatically close when the 'settings'
button is clicked, so that the settings page is shown without the
popup partially obscuring it.

This seems a bit cleaner/nicer than needing to click around in the
settings page to get rid of the popup.

Note: I'm using the 2.X.X branch because other PRs seem to, but let me know if that's incorrect. The _contributing_ section in the README doesn't mention where to branch features from :)