### PR TITLE
Add delay before rendering popup on Chrome

### DIFF
--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -9,6 +9,7 @@
   </head>
   <body>
     <script type="text/javascript" src="../global_files/browser-polyfill.js"></script>
+    <script src="../global_files/browserDetect.js"></script>
     <script src="../global_files/react.min.js"></script>
     <script src="../global_files/react-dom.min.js"></script>
     <script src="../global_files/redux.js"></script>

--- a/src/ui/popup/index.js
+++ b/src/ui/popup/index.js
@@ -9,6 +9,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 **/
+/* global browserDetect */
 import React from "react";
 import ReactDOM from "react-dom";
 import {Provider} from "react-redux";
@@ -19,6 +20,10 @@ async function initApp() {
 	const store = await createUIStore();
 	const mountNode = document.createElement("div");
 	document.body.appendChild(mountNode);
+
+	if (browserDetect() === "Chrome") {
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
 
 	ReactDOM.render(
 		<Provider store={store}>


### PR DESCRIPTION
Add 100ms delay before rendering popup on Chrome.
This is a workaround for #311.