### PR TITLE
Version Number and Log Timezone Name Additions

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -503,5 +503,10 @@
   "noCleanupLogText": {
     "message": "No Cleanup Logs Found",
     "description": "No Cleanup Logs Found"
+  },
+
+  "versionExtText": {
+    "message": "version",
+    "description": "version",
   }
 }

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -507,6 +507,6 @@
 
   "versionExtText": {
     "message": "version",
-    "description": "version",
+    "description": "version"
   }
 }

--- a/extension/settings/side-menu.css
+++ b/extension/settings/side-menu.css
@@ -7,6 +7,10 @@ body {
   height: auto;
 }
 
+.sidebar-version {
+  padding-bottom: 1em;
+}
+
 /*
 Add transition to containers so they can push in and out.
 */

--- a/src/background.ts
+++ b/src/background.ts
@@ -66,6 +66,7 @@ const onSettingsChange = () => {
 };
 
 const onStartUp = async () => {
+  browser.browserAction.setTitle({ title: `${await browser.browserAction.getTitle({})} {browser.runtime.getManifest().version}` });
   const storage = await browser.storage.local.get();
   let stateFromStorage;
   try {

--- a/src/background.ts
+++ b/src/background.ts
@@ -66,7 +66,7 @@ const onSettingsChange = () => {
 };
 
 const onStartUp = async () => {
-  browser.browserAction.setTitle({ title: `${await browser.browserAction.getTitle({})} {browser.runtime.getManifest().version}` });
+  browser.browserAction.setTitle({ title: `${await browser.browserAction.getTitle({})} ${browser.runtime.getManifest().version}` });
   const storage = await browser.storage.local.get();
   let stateFromStorage;
   try {

--- a/src/ui/common_components/ActivityTable.tsx
+++ b/src/ui/common_components/ActivityTable.tsx
@@ -211,7 +211,7 @@ const ActivityTable: React.FunctionComponent<ActivityTableProps> = props => {
                   aria-expanded="false"
                   aria-controls={`collapse${index}`}
                 >
-                  {`${new Date(log.dateTime).toLocaleString()} - ${message}`}
+                  {`${new Date(log.dateTime).toLocaleString([], { timeZoneName: 'short' })} - ${message}`}
                 </button>
               </h5>
             </div>

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -18,6 +18,7 @@ const About: React.FunctionComponent<OwnProps> = props => {
   return (
     <div style={style}>
       <h1>{browser.i18n.getMessage('aboutText')}</h1>
+      <h5>{browser.i18n.getMessage('versionText', [''])}: <b>{browser.runtime.getManifest().version}</b></h5>
       <a href="https://github.com/mrdokenny/Cookie-AutoDelete/issues">
         {browser.i18n.getMessage('reportIssuesText')}
       </a>{' '}

--- a/src/ui/settings/components/SideBar.tsx
+++ b/src/ui/settings/components/SideBar.tsx
@@ -116,6 +116,7 @@ class SideBar extends React.Component<OwnProps> {
                 <span>{`${element.tabText}`}</span>
               </div>
             ))}
+
             <div
               style={{
                 bottom: '5px',
@@ -129,7 +130,8 @@ class SideBar extends React.Component<OwnProps> {
                 style={{
                   textAlign: 'center',
                   width: '100%',
-                }}>
+                }}
+              >
                 {browser.i18n.getMessage('contributeText')}
               </a>
             </div>

--- a/src/ui/settings/components/SideBar.tsx
+++ b/src/ui/settings/components/SideBar.tsx
@@ -95,6 +95,14 @@ class SideBar extends React.Component<OwnProps> {
 
         <div id="menu">
           <div className="pure-menu">
+            <div
+              className="sidebar-version"
+              style={{
+                  textAlign: 'center',
+                  width: '100%',
+              }}>
+              <span>CAD {browser.i18n.getMessage('versionText', [''])} <b>{browser.runtime.getManifest().version}</b></span>
+            </div>
             {sideBarTabs.map((element, index) => (
               <div
                 key={element.tabId}
@@ -107,22 +115,19 @@ class SideBar extends React.Component<OwnProps> {
                 <span>{`${element.tabText}`}</span>
               </div>
             ))}
-
             <div
               style={{
                 bottom: '5px',
                 position: 'absolute',
                 width: '100%',
-              }}
-            >
+              }}>
               <a
                 href="https://www.paypal.me/mrkennyd/5"
                 className="btn"
                 style={{
                   textAlign: 'center',
                   width: '100%',
-                }}
-              >
+                }}>
                 {browser.i18n.getMessage('contributeText')}
               </a>
             </div>

--- a/src/ui/settings/components/SideBar.tsx
+++ b/src/ui/settings/components/SideBar.tsx
@@ -100,7 +100,8 @@ class SideBar extends React.Component<OwnProps> {
               style={{
                   textAlign: 'center',
                   width: '100%',
-              }}>
+              }}
+            >
               <span>CAD {browser.i18n.getMessage('versionText', [''])} <b>{browser.runtime.getManifest().version}</b></span>
             </div>
             {sideBarTabs.map((element, index) => (
@@ -120,7 +121,8 @@ class SideBar extends React.Component<OwnProps> {
                 bottom: '5px',
                 position: 'absolute',
                 width: '100%',
-              }}>
+              }}
+            >
               <a
                 href="https://www.paypal.me/mrkennyd/5"
                 className="btn"


### PR DESCRIPTION
Closes #443 and possibly closes #474.

(Apologies - I forgot to create a separate branch for these separate 'bugfixes'.  Hopefully you're fine with implementing both at once)

Added version number in three places:  

- Icon Title (viewable upon mouse-over or in the firefox overflow menu)
![screenshot from 2019-01-31 22-02-14](https://user-images.githubusercontent.com/6724477/52105565-fc0b3280-25a3-11e9-96ea-c3b774e7f5ed.png)

- Sidebar menu navigation in Settings
![screenshot from 2019-01-31 22-03-32](https://user-images.githubusercontent.com/6724477/52105585-1ba25b00-25a4-11e9-92a7-88c29315859e.png)

- About page
![screenshot from 2019-01-31 22-04-30](https://user-images.githubusercontent.com/6724477/52105618-3ecd0a80-25a4-11e9-8d36-86962289ec4d.png)

Value is extracted from the manifest file from within the browser itself, so there's still only one version number to keep updated.

-----

For the log times, I've added in the option to display the short timezone name that is based on what is already stored by the timestamp itself.
![screenshot from 2019-01-31 22-31-40](https://user-images.githubusercontent.com/6724477/52106670-83f33b80-25a8-11e9-8831-2a6c792a717a.png)
