### PR TITLE
Added Versioning on Notifications Popup

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -10,8 +10,14 @@
   },
 
   "notificationTitle": {
-    "message": "Cookie AutoDelete: Cookies were deleted!",
-    "description": "Cookie AutoDelete: Cookies were deleted!"
+    "message": "Cookie AutoDelete $Ver$: Cookies were deleted!",
+    "description": "Cookie AutoDelete 3.X.X: Cookies were deleted!",
+    "placeholders": {
+      "ver": {
+        "content": "$1",
+        "example": "3.0.0"
+      }
+    }
   },
 
   "notificationContent": {
@@ -503,10 +509,5 @@
   "noCleanupLogText": {
     "message": "No Cleanup Logs Found",
     "description": "No Cleanup Logs Found"
-  },
-
-  "versionExtText": {
-    "message": "version",
-    "description": "version"
   }
 }

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -203,7 +203,7 @@ export const cookieCleanup: ActionCreator<
     browser.notifications.create(COOKIE_CLEANUP_NOTIFICATION, {
       iconUrl: browser.extension.getURL('icons/icon_48.png'),
       message: notifyMessage,
-      title: browser.i18n.getMessage('notificationTitle'),
+      title: browser.i18n.getMessage('notificationTitle', [browser.runtime.getManifest().version]),
       type: 'basic',
     });
     const seconds = parseInt(


### PR DESCRIPTION
Thought I should do this as well, before you publish a new version.   As the title says, this adds the version number to the popup.

I am unsure if you had used the `notificationTitle` locale string anywhere else, so let me know if I need to commit additional changes to this PR first.

Removed `versionExtText` from my previous PR #494 as I found out that I used a workaround instead based on your current locales string for mentioning browser version.

For those looking for a screenshot, here you go.  Nothing too fancy.
![screenshot from 2019-02-21 14-46-30](https://user-images.githubusercontent.com/6724477/53207933-f96f8c00-35e9-11e9-9962-defce73060c0.png)
