### PR TITLE
Changed min Firefox version to 63

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -27,7 +27,7 @@
   "applications": {
     "gecko": {
       "id": "CookieAutoDelete@kennydo.com",
-      "strict_min_version": "59.0"
+      "strict_min_version": "63.0"
     }
   },
   "options_ui": {


### PR DESCRIPTION
due to browserAction.setBadgeTextColor() in Firefox.

Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>