### PR TITLE
Miscellaneous Enhancements

### DIFF
--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -543,6 +543,17 @@ describe('Library Functions', () => {
       const result = await sleep(1);
       expect(result).toBe(undefined);
     });
+    it('should return after 1.5 seconds (max 15 ms past)', () => {
+      expect.assertions(3);
+      const start = new Date().getTime();
+      const result = sleep(1500);
+      return result.then(data => {
+        const duration = new Date().getTime() - start;
+        expect(duration).toBeGreaterThanOrEqual(1500);
+        expect(duration).toBeLessThan(1515);
+        expect(data).toBe(undefined);
+      })
+    })
   });
 
   describe('throwErrorNotification()', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "cookie-autodelete",
-<<<<<<< HEAD
   "version": "3.2.0",
-=======
-  "version": "3.1.1",
->>>>>>> Version Bump
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,10 @@
 {
   "name": "cookie-autodelete",
+<<<<<<< HEAD
   "version": "3.2.0",
+=======
+  "version": "3.1.1",
+>>>>>>> Version Bump
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -143,7 +143,7 @@ export const resetAll = (): RESET_ALL => ({
 export const validateSettings: ActionCreator<
   ThunkAction<void, State, null, ReduxAction>
 > = () => (dispatch, getState) => {
-  const { settings } = getState();
+  const { cache, settings } = getState();
   const initialSettings = initialState.settings;
   const settingKeys = Object.keys(settings);
   const initialSettingKeys = Object.keys(initialSettings);
@@ -172,6 +172,29 @@ export const validateSettings: ActionCreator<
         });
       }
     });
+  }
+
+  function disableSettingIfTrue(s: Setting) {
+    if (s && s.value){
+      dispatch({
+        payload: {
+          ...s,
+          value: false,
+        },
+        type: ReduxConstants.UPDATE_SETTING,
+      });
+    }
+  }
+
+  // Disable unusable setting in Chrome
+  if (cache.browserDetect === 'Chrome') {
+    disableSettingIfTrue(settings.contextualIdentities);
+  }
+  // Disable unusable setting in Firefox Android
+  if (cache.browserDetect === 'Firefox' && cache.platformOs === 'android') {
+    disableSettingIfTrue(settings.showNumOfCookiesInIcon);
+    disableSettingIfTrue(settings.localstorageCleanup);
+    disableSettingIfTrue(settings.contextualIdentities);
   }
 };
 

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -122,21 +122,24 @@ const Settings: React.FunctionComponent<SettingProps> = props => {
         </div>
       </div>
 
-      <div className="row" style={styles.rowOverrides}>
-        <div className="col">
-          <CheckboxSetting
-            text={browser.i18n.getMessage('showNumberOfCookiesInIconText')}
-            settingObject={settings.showNumOfCookiesInIcon}
-            inline={true}
-            updateSetting={payload => onUpdateSetting(payload)}
-          />
-          <SettingsTooltip
-            hrefURL={
-              '#show-number-of-cookies-for-that-domain'
-            }
-          />
+      {(browserDetect !== 'Firefox' || platformOs !== 'android') && (
+        <div className="row" style={styles.rowOverrides}>
+          <div className="col">
+            <CheckboxSetting
+              text={browser.i18n.getMessage('showNumberOfCookiesInIconText')}
+              settingObject={settings.showNumOfCookiesInIcon}
+              inline={true}
+              updateSetting={payload => onUpdateSetting(payload)}
+            />
+            <SettingsTooltip
+              hrefURL={
+                '#show-number-of-cookies-for-that-domain'
+              }
+            />
+          </div>
         </div>
-      </div>
+      )}
+
 
       <div className="row" style={styles.rowOverrides}>
         <div className="col">


### PR DESCRIPTION
- Hide settings not usable in Chrome or Firefox Android.
  - Unusable in Android:  showNumberOfCookiesInIcon, contextualIdentities, localstorage
  - Unusable in Chrome:  contextualIdentities
- Additional Validation Setting for Chrome or Firefox Android per above.
  - This makes some settings false if it is not supported.
- Additional test to Libs.ts