### PR TITLE
330 patch

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -174,3 +174,4 @@ module.exports = {
   // Whether to use watchman for file crawling
   // watchman: true,
 };
+process.env = Object.assign(process.env, { JEST_TEST: true });

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -305,7 +305,7 @@ export const filterLocalstorage = (obj: CleanReasonObject, debug: boolean = fals
   const nonBlankCookieHostName = obj.cookie.hostname.trim() !== '';
   if (debug) {
     cadLog({
-      msg: 'CleanupService.filterLocalstorage results.',
+      msg: 'CleanupService.filterLocalstorage: debug data.',
       x: {notProtectedByOpenTab, notInAnyLists, listCleanLocalstorage, nonBlankCookieHostName, clean1: notInAnyLists, clean2: (notProtectedByOpenTab && listCleanLocalstorage) , CleanReasonObject: obj},
     });
   }
@@ -436,7 +436,7 @@ export const cleanCookiesOperation = async (
       const r = filterLocalstorage(obj, debug);
       if (debug) {
         cadLog({
-          msg: `CleanupService.filterLocalstorage returned: ${r} for ${obj.cookie.hostname}`
+          msg: `CleanupService.filterLocalstorage: returned ${r} for ${obj.cookie.hostname}`
         });
       }
       return r;

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -361,11 +361,24 @@ export const cleanCookiesOperation = async (
   const cookieStoreIds = new Set<string>();
 
   // Manually add default containers.
-  cookieStoreIds.add('default');
-  cookieStoreIds.add('firefox-default');
-  if (await browser.extension.isAllowedIncognitoAccess()) {
-    cookieStoreIds.add('firefox-private');
-    cookieStoreIds.add('private');
+  console.info(state.cache);
+  switch(state.cache.browserDetect) {
+    case 'Firefox':
+      cookieStoreIds.add('default');
+      cookieStoreIds.add('firefox-default');
+      if (await browser.extension.isAllowedIncognitoAccess()) {
+        cookieStoreIds.add('firefox-private');
+        cookieStoreIds.add('private');
+      }
+      break;
+    case 'Chrome':
+      cookieStoreIds.add('0');
+      if (await browser.extension.isAllowedIncognitoAccess()) {
+        cookieStoreIds.add('1');
+      }
+      break;
+    default:
+      break;
   }
 
   // Store cookieStoreIds from the contextualIdentities API

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -263,9 +263,7 @@ export const prepareCookieDomain = (cookie: browser.cookies.Cookie) => {
 
   const sDot = cookieDomain.startsWith('.') ? 1 : 0;
 
-  return cookie.secure
-    ? `https://${cookieDomain.slice(sDot)}${cookie.path}`
-    : `http://${cookieDomain.slice(sDot)}${cookie.path}`;
+  return `http${cookie.secure ? 's' : ''}://${cookieDomain.slice(sDot)}${cookie.path}`;
 };
 
 /**

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -113,7 +113,7 @@ export default class TabEvents extends StoreUser {
           if (debug) {
             cadLog({
               msg: 'TabEvents.onDomainChange: mainDomain has changed.  Executing domainChangeCleanup',
-              x: {tabId, changeInfo, oldMainDomain: TabEvents.tabToDomain[tabId], mainDomain, partialTabInfo,},
+              x: {tabId, changeInfo, oldMainDomain, mainDomain, partialTabInfo,},
             });
           }
           TabEvents.cleanFromFromTabEvents();
@@ -121,7 +121,7 @@ export default class TabEvents extends StoreUser {
           if (debug) {
             cadLog({
               msg: 'TabEvents.onDomainChange: mainDomain has changed, but cleanOnDomainChange is not enabled.  Not cleaning.',
-              x: {tabId, changeInfo, oldMainDomain: TabEvents.tabToDomain[tabId], mainDomain, partialTabInfo,},
+              x: {tabId, changeInfo, oldMainDomain, mainDomain, partialTabInfo,},
             });
           }
         }

--- a/src/typings/Webext.d.ts
+++ b/src/typings/Webext.d.ts
@@ -22,7 +22,6 @@ declare namespace browser.browsingData {
 declare namespace browser.cookies {
   interface CookieProperties extends browser.cookies.Cookie {
     firstPartyDomain?: string;
-    sameSite?: string;
   }
   type OptionalCookieProperties = Partial<CookieProperties>;
 }


### PR DESCRIPTION
This patch fixes localstorage cleaning on browser restart.
This also fixes chrome storeId bug introduced when trying to add default containers/storeId to fetch cookies from.
Also add some additional tests and some debug info.