### PR TITLE
Unit Tests for TabEvents.

### DIFF
--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -23,7 +23,6 @@ for (const k of Object.keys(Lib)) {
     if (!spyLib[k]) spyLib[k] = jest.spyOn(Lib, k as never);
   } catch {
     // Most likely not a function
-    continue;
   }
 }
 

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -1,0 +1,394 @@
+/**
+ * Copyright (c) 2020 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { when } from 'jest-when';
+import { Store } from 'redux';
+
+import { resetSettings, updateSetting } from '../../src/redux/Actions';
+import { initialState } from '../../src/redux/State';
+// tslint:disable-next-line: import-name
+import createStore from '../../src/redux/Store';
+import { ReduxAction, ReduxConstants } from '../../src/typings/ReduxConstants';
+import AlarmEvents from '../../src/services/AlarmEvents';
+import * as Lib from '../../src/services/Libs';
+import TabEvents from '../../src/services/TabEvents';
+import StoreUser from '../../src/services/StoreUser';
+
+jest.requireActual('../../src/services/AlarmEvents');
+
+// This dynamically generates the spies for all functions in AlarmEvents
+const spyAlarmEvents: {[s: string]: jest.SpyInstance} = {};
+for (const k of Object.keys(AlarmEvents)) {
+  try {
+    if (!spyAlarmEvents[k]) spyAlarmEvents[k] = jest.spyOn(AlarmEvents, k as never);
+  } catch {
+    // Most likely not a function
+  }
+}
+
+jest.requireActual('../../src/services/Libs');
+
+// This dynamically generates the spies for all functions in Libs
+const spyLib: {[s: string]: jest.SpyInstance} = {};
+for (const k of Object.keys(Lib)) {
+  try {
+    if (!spyLib[k]) spyLib[k] = jest.spyOn(Lib, k as never);
+  } catch {
+    // Most likely not a function
+  }
+}
+jest.requireActual('../../src/services/TabEvents');
+
+// This dynamically generates the spies for all functions in TabEvents
+const spyTabEvents: {[s: string]: jest.SpyInstance} = {};
+for (const k of Object.keys(TabEvents)) {
+  try {
+    if (!spyTabEvents[k]) spyTabEvents[k] = jest.spyOn(TabEvents, k as never);
+  } catch {
+    // Most likely not a function
+  }
+}
+
+jest.requireActual('../../src/services/StoreUser');
+
+jest.useFakeTimers();
+
+const store: Store<State, ReduxAction> = createStore(initialState);
+StoreUser.init(store);
+
+class TestStore extends StoreUser {
+
+  public static addCache(payload: any) {
+    StoreUser.store.dispatch({
+      payload,
+      type: ReduxConstants.ADD_CACHE
+    });
+  };
+
+  public static changeSetting(name: string, value: string | boolean | number) {
+    StoreUser.store.dispatch(updateSetting({ name, value }));
+  }
+
+  public static resetSetting() {
+    StoreUser.store.dispatch(resetSettings());
+  }
+}
+
+const sampleChangeInfo: browser.tabs.TabChangeInfo = {
+  discarded: false,
+  favIconUrl: 'sample',
+  status: 'loading|complete',
+  title: 'newTitle',
+  url: 'sampleURL',
+}
+
+const sampleTab: browser.tabs.Tab = {
+  active: true,
+  cookieStoreId: 'firefox-default',
+  discarded: false,
+  hidden: false,
+  highlighted: false,
+  incognito: false,
+  index: 0,
+  isArticle: false,
+  isInReaderMode: false,
+  lastAccessed: 12345678,
+  pinned: false,
+  selected: true,
+  url: 'https://www.example.com',
+  windowId: 1,
+}
+
+describe('TabEvents', () => {
+  beforeAll(() => {
+    when(global.browser.runtime.getManifest)
+      .calledWith()
+      .mockReturnValue({version: '0.12.34' } as never);
+    when(global.browser.cookies.getAll)
+      .calledWith(expect.any(Object))
+      .mockResolvedValue([] as never);
+    // Required so the actual cleaning functions being awaited won't run.
+    when(spyAlarmEvents.createActiveModeAlarm)
+      .calledWith()
+      .mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.runAllTimers();
+    jest.clearAllTimers();
+    TestStore.resetSetting();
+  });
+
+  describe('getAllCookieActions', () => {
+    beforeAll(() => {
+      when(global.browser.cookies.getAll)
+        .calledWith({storeId: 'firefox-default'})
+        .mockResolvedValue([testCookie, {...testCookie, domain: '', path: '/test/'}] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({domain: ''})
+        .mockResolvedValue([] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({domain: 'domain.com', storeId: 'firefox-default'})
+        .mockResolvedValue([testCookie] as never);
+    });
+
+    const testCookie: browser.cookies.Cookie = {
+      domain: 'domain.com',
+      hostOnly: true,
+      httpOnly: true,
+      name: 'blah',
+      path: '/',
+      sameSite: 'no_restriction',
+      secure: true,
+      session: true,
+      storeId: 'firefox-default',
+      value: 'test value',
+    };
+
+    it('should do nothing if url is undefined', async () => {
+      await TabEvents.getAllCookieActions({...sampleTab, url: undefined});
+      expect(spyLib.cadLog).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if url is empty string', async () => {
+      await TabEvents.getAllCookieActions({...sampleTab, url: ''});
+      expect(spyLib.cadLog).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if url is an internal page', async () => {
+      await TabEvents.getAllCookieActions({...sampleTab, url: 'about:home'});
+      await TabEvents.getAllCookieActions({...sampleTab, url: 'chrome:newtab'});
+      expect(spyLib.cadLog).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if url is not valid', async () => {
+      await TabEvents.getAllCookieActions({...sampleTab, url: 'bad'});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('empty')).not.toBe(-1);
+    });
+
+    it('should work on local files', async () => {
+      await TabEvents.getAllCookieActions({...sampleTab, url: 'file:///test/file.html'});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('Local')).not.toBe(-1);
+      // Well a simple test but at least we cover that path somewhat.\
+      expect(spyLib.cadLog.mock.calls[1][0].x.cookieCount).toBe(1);
+    });
+
+    it('should work on regular domains', async () => {
+      await TabEvents.getAllCookieActions({...sampleTab, url: 'http://domain.com'});
+      expect(spyLib.cadLog.mock.calls[1][0].x.cookieCount).toBe(1);
+    });
+
+    it('should create a cookie if clean localstorage was enabled and no cookie was found', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({domain: 'cookie.net', storeId: 'firefox-default'})
+        .mockResolvedValue([] as never);
+      TestStore.changeSetting('localstorageCleanup', true);
+      await TabEvents.getAllCookieActions({...sampleTab, url: 'http://cookie.net'});
+      expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('should filter out CAD LocalStorage cookie from total cookie count', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({domain: 'cookie.net', storeId: 'firefox-default'})
+        .mockResolvedValue([{...testCookie, name: Lib.LSCLEANUPNAME}] as never);
+      await TabEvents.getAllCookieActions({...sampleTab, url: 'http://cookie.net'});
+      expect(spyLib.cadLog.mock.calls[2][0].x).toEqual({
+        preFilterCount: 1, newCookieCount: 0,
+      });
+    });
+
+    it('should not show cookie count in non-existent icon in Firefox Android', async () => {
+      TestStore.addCache({key: 'platformOs', value: 'android'});
+      await TabEvents.getAllCookieActions({...sampleTab, url: 'http://domain.com'});
+      // dynamically get last call to cadLog
+      const cl = spyLib.cadLog.mock.calls.length - 1;
+      // This makes sure that showNumberOfCookiesInIcon is not called
+      expect(spyLib.cadLog.mock.calls[cl][0].msg.indexOf('showNumberOfCookiesInIcon')).toBe(-1);
+    });
+  });
+
+  describe('onTabDiscarded', () => {
+    it('should do nothing if clean discarded tabs setting is not enabled', () => {
+      TestStore.changeSetting('discardedCleanup', false);
+      TabEvents.onTabDiscarded(0, sampleChangeInfo, sampleTab);
+      expect(spyLib.createPartialTabInfo).not.toHaveBeenCalled();
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if the tab that was updated is not discarded, even if discardedCleanup was true', () => {
+      TestStore.changeSetting('discardedCleanup', true);
+      TabEvents.onTabDiscarded(0, sampleChangeInfo, sampleTab);
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+
+    it('should trigger cleaning if clean discarded tabs is enabled and changeInfo was discarded', () => {
+      TestStore.changeSetting('discardedCleanup', true);
+      TabEvents.onTabDiscarded(0, {...sampleChangeInfo, discarded: true}, sampleTab);
+      expect(spyTabEvents.cleanFromTabEvents).toHaveBeenCalledTimes(1);
+    });
+
+    it('should sanitize favIconUrl if debug was enabled', () => {
+      TestStore.changeSetting('discardedCleanup', true);
+      TestStore.changeSetting('debugMode', true);
+      TabEvents.onTabDiscarded(0, {...sampleChangeInfo}, sampleTab);
+      expect(spyLib.cadLog.mock.calls[0][0].x.changeInfo.favIconUrl).toBe('***');
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onTabUpdate', () => {
+    beforeAll(() => {
+      when(spyTabEvents.getAllCookieActions)
+        .calledWith()
+        .mockResolvedValue(undefined as any);
+    });
+    afterAll(() => {
+      spyTabEvents.getAllCookieActions.mockRestore();
+    });
+
+    it('should do nothing if tab status is not "complete"', () => {
+      TabEvents.onTabUpdate(0, sampleChangeInfo, {...sampleTab, status: 'loading'});
+      expect(spyTabEvents.getAllCookieActions).not.toHaveBeenCalled();
+    });
+
+    it('should trigger getAllCookieActions', () => {
+      TabEvents.onTabUpdate(0, sampleChangeInfo, { ...sampleTab, status: 'complete' });
+      jest.runAllTimers();
+      expect(spyTabEvents.getAllCookieActions).toHaveBeenCalledTimes(1);
+    });
+
+    it('should sanitize favIconUrl if status=complete and debug is true', () => {
+      TestStore.changeSetting('debugMode', true);
+      TabEvents.onTabUpdate(0, sampleChangeInfo, { ...sampleTab, status: 'complete' });
+      jest.runAllTimers();
+      expect(spyLib.cadLog.mock.calls[0][0].x.changeInfo.favIconUrl).toBe('***');
+    });
+
+    it('should not queue getAllCookieActions if one is pending already', () => {
+      TestStore.changeSetting('debugMode', true);
+      TabEvents.onTabUpdate(0, sampleChangeInfo, { ...sampleTab, status: 'complete' });
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('set')).not.toBe(-1);
+      TabEvents.onTabUpdate(0, sampleChangeInfo, { ...sampleTab, status: 'complete' });
+      expect(spyLib.cadLog.mock.calls[1][0].msg.indexOf('pending')).not.toBe(-1);
+      jest.runAllTimers();
+    });
+  });
+
+  describe('onDomainChange', () => {
+    // Because it is not easy checking private variables, use cadLog's inbound msg
+    // to check, even though it is not being output if debug=false.
+    //       spyLib.cadLog.mock.calls[0][0] for first call & first argument
+
+    // Do not change any of the test order as each test relies on the previous actions.
+
+    it('should do nothing if tab.status is not complete', () => {
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'loading'});
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+
+    it('should set mainDomain on first encounter', () => {
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'complete'});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('First')).not.toBe(-1);
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+
+    it('should truncate favIconUrl if debug=true', () => {
+      TestStore.changeSetting('debugMode', true);
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'complete'});
+      expect(spyLib.cadLog.mock.calls[0][0].x.changeInfo.favIconUrl).toBe('***');
+    });
+
+    it('should not do anything if mainDomain has not changed yet', () => {
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'complete'});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('not changed')).not.toBe(-1);
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger clean if cleanOnDomainChange was not enabled', () => {
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'complete', url: 'http://domain.cad'});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('not enabled')).not.toBe(-1);
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+
+    it('should trigger clean if mainDomain was changed and domainChangeCleanup is enabled', () => {
+      TestStore.changeSetting('domainChangeCleanup', true);
+      // reuse previous tabId to change domain
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'complete'});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('changed.  Executing')).not.toBe(-1);
+      expect(spyTabEvents.cleanFromTabEvents).toHaveBeenCalledTimes(1);
+    });
+
+    it('should trigger clean if mainDomain was changed to a home/blank/new tab and domainChangeCleanup is enabled', () => {
+      TestStore.changeSetting('domainChangeCleanup', true);
+      // reuse previous tabId to change domain to blank
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'complete', url: 'about:blank'});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('changed.  Executing')).not.toBe(-1);
+      expect(spyTabEvents.cleanFromTabEvents).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not trigger cleaning if previous domain was a new/blank/home tab with domainChangeCleanup enabled', () => {
+      TestStore.changeSetting('domainChangeCleanup', true);
+      // reuse previous tabId of blank tab to new domain.
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'complete'});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('blank')).not.toBe(-1);
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger if next domain is an empty string (highly unlikely scenario)', () => {
+      TestStore.changeSetting('domainChangeCleanup', true);
+      // reuse previous tabId to go from domain to empty string...which usually doesn't happen
+      TabEvents.onDomainChange(0, sampleChangeInfo, {...sampleTab, status: 'complete', url: ''});
+      // Treat as mainDomain unchanged per current logic.
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('not changed')).not.toBe(-1);
+      expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onDomainChangeRemove', () => {
+    // This function doesn't throw any errors when tabId does not exist, so one test covers all.
+    it('should remove old mainDomain from closed tabId', () => {
+      TabEvents.onDomainChangeRemove(0, {windowId: 1, isWindowClosing: false,});
+      expect(spyLib.cadLog.mock.calls[0][0].msg.indexOf('Removing')).not.toBe(-1);
+    });
+  });
+
+  describe('cleanFromTabEvents', () => {
+    afterAll(() => {
+      global.browser.alarms.get.mockRestore();
+    });
+
+    it('should do nothing if activeMode is disabled', async () => {
+      await TabEvents.cleanFromTabEvents();
+      expect(spyLib.cadLog.mock.calls.length).toBe(0);
+    });
+
+    it('should create an "alarm" for cleaning when activeMode is enabled', async () => {
+      when(global.browser.alarms.get)
+        .calledWith('activeModeAlarm')
+        .mockResolvedValue(undefined as never);
+      TestStore.changeSetting('activeMode', true);
+      TestStore.changeSetting('delayBeforeClean', 1);
+      await TabEvents.cleanFromTabEvents();
+      expect(spyAlarmEvents.createActiveModeAlarm).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not create an alarm if one exists already when activeMode is enabled', async () => {
+      when(global.browser.alarms.get)
+        .calledWith('activeModeAlarm')
+        .mockResolvedValue({name: 'activeModeAlarm'} as never);
+      TestStore.changeSetting('activeMode', true);
+      await TabEvents.cleanFromTabEvents();
+      expect(spyAlarmEvents.createActiveModeAlarm).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -26,29 +26,15 @@
 
 // event listeners
 const eventListeners = {
-  listeners: [],
-  addListener: jest.fn(function() {
-    if (arguments.length === 1 && !listeners.includes(argument[0])) {
-      listeners.push(arguments[0]);
-    }
-  }),
-  clearListeners: jest.fn(function() {
-    if (arguments.length === 0) {
-      listeners = [];
-    }
-  }),
-  hasListener: jest.fn(function() {
-    return arguments.length === 1 && listeners.includes(arguments[0]);
-  }),
-  removeListener: jest.fn(function() {
-    if (arguments.length === 1) {
-      listeners = listeners.filter(l => l !== arguments[0]);
-    }
-  }),
+  addListener: jest.fn(),
+  clearListeners: jest.fn(),
+  hasListener: jest.fn(),
+  removeListener: jest.fn(),
 };
 
 // storage functions
 const storageArea = {
+  storage: {},
   get: jest.fn(),
   set: jest.fn(),
   remove: jest.fn(),
@@ -56,7 +42,7 @@ const storageArea = {
 };
 
 const apis = {
-  alarm: {
+  alarms: {
     fn: ['clear', 'clearAll', 'create', 'get', 'getAll'],
   },
   browserAction: {
@@ -146,6 +132,7 @@ Object.keys(apis).forEach(api => {
 });
 
 global.browser = browser;
+global.chrome = browser;
 // Hide test console debug logs from jest results.
 
 global.console = {

--- a/src/services/AlarmEvents.ts
+++ b/src/services/AlarmEvents.ts
@@ -16,26 +16,26 @@ import { getSetting, sleep } from './Libs';
 import StoreUser from './StoreUser';
 
 export default class AlarmEvents extends StoreUser {
-  public static async createActiveModeAlarm() {
+  public static createActiveModeAlarm = async () => {
     const seconds = parseInt(
-      getSetting(this.store.getState(), 'delayBeforeClean') as string,
+      getSetting(StoreUser.store.getState(), 'delayBeforeClean') as string,
       10,
     );
     const milliseconds = (seconds > 0 ? seconds : 0.5) * 1000;
-    if (this.alarmFlag) {
+    if (AlarmEvents.alarmFlag) {
       return;
     }
-    this.alarmFlag = true;
+    AlarmEvents.alarmFlag = true;
     await sleep(milliseconds);
-    if (getSetting(this.store.getState(), 'activeMode')) {
-      this.store.dispatch<any>(
+    if (getSetting(StoreUser.store.getState(), 'activeMode')) {
+      StoreUser.store.dispatch<any>(
         cookieCleanup({
           greyCleanup: false,
           ignoreOpenTabs: false,
         }),
       );
     }
-    this.alarmFlag = false;
+    AlarmEvents.alarmFlag = false;
   }
   // Create an alarm delay or use setTimeout before cookie cleanup
   private static alarmFlag = false;

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -18,10 +18,12 @@ export const showNumberOfCookiesInIcon = (
   tab: browser.tabs.Tab,
   cookieLength: number,
 ) => {
-  browser.browserAction.setBadgeText({
-    tabId: tab.id,
-    text: `${cookieLength === 0 ? '' : cookieLength.toString()}`,
-  });
+  if (browser.browserAction.setBadgeText) {
+    browser.browserAction.setBadgeText({
+      tabId: tab.id,
+      text: `${cookieLength === 0 ? '' : cookieLength.toString()}`,
+    });
+  }
   if (browser.browserAction.setBadgeTextColor) {
     browser.browserAction.setBadgeTextColor({
       color: 'white',
@@ -31,7 +33,7 @@ export const showNumberOfCookiesInIcon = (
 };
 
 // Set BrowserAction Title with number of cookies in square brackets.
-export const showNumberofCookiesinTitle = async (
+export const showNumberOfCookiesInTitle = async (
   tab: browser.tabs.Tab,
   otherInfo: {
     cookieLength?: number,
@@ -43,7 +45,7 @@ export const showNumberofCookiesinTitle = async (
   // Use Shortened Extension name for mobile.
   const tabTitle = `${((otherInfo.platformOS === 'android') ? 'CAD' : mf.name)} ${mf.version}`;
 
-  const curData = /\[(.*)\] \((\d*)\)/.exec(await browser.browserAction.getTitle({
+  const curData = /\[(.*)] \((\d*)\)/.exec(await browser.browserAction.getTitle({
     tabId: tab.id,
   }));
   const newData = {
@@ -68,7 +70,7 @@ const setBadgeColor = (tab: browser.tabs.Tab, color: string = 'default') => {
     browser.browserAction.setBadgeBackgroundColor({
       color: badgeBackgroundColor[color],
       tabId: tab.id,
-    })
+    });
   }
 }
 
@@ -140,9 +142,9 @@ export const checkIfProtected = async (
     );
 
     if (matchedExpression) {
-      showNumberofCookiesinTitle(aTab, {platformOS: state.cache.platformOs, listType: matchedExpression.listType, cookieLength,});
+      showNumberOfCookiesInTitle(aTab, {platformOS: state.cache.platformOs, listType: matchedExpression.listType, cookieLength,});
     } else {
-      showNumberofCookiesinTitle(aTab, {platformOS: state.cache.platformOs, listType: 'NO LIST', cookieLength,});
+      showNumberOfCookiesInTitle(aTab, {platformOS: state.cache.platformOs, listType: 'NO LIST', cookieLength,});
     }
 
     // Can't set icons on Android.

--- a/src/services/StoreUser.ts
+++ b/src/services/StoreUser.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file: Redux init. */
+
 /**
  * Copyright (c) 2017-2020 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
@@ -10,7 +12,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-/* istanbul ignore file: Redux init.*/
 import { Store } from 'redux';
 import { ReduxAction } from '../typings/ReduxConstants';
 

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -189,7 +189,6 @@ export default class TabEvents extends StoreUser {
     const debug = getSetting(StoreUser.store.getState(), 'debugMode') as boolean;
     const partialTabInfo = createPartialTabInfo(tab);
     const hostname = getHostname(tab.url);
-    const firstPartyIsolate = await isFirstPartyIsolate();
     if (hostname === '') {
       cadLog({
         msg: 'TabEvents.getAllCookieActions: hostname parsed empty for tab url.  Skipping Cookie Actions.',
@@ -197,6 +196,7 @@ export default class TabEvents extends StoreUser {
       }, debug);
       return;
     }
+    const firstPartyIsolate = await isFirstPartyIsolate();
     let cookies: browser.cookies.Cookie[];
     if (hostname.startsWith('file:')){
       const allCookies = await browser.cookies.getAll(
@@ -274,7 +274,7 @@ export default class TabEvents extends StoreUser {
     }
   }
   // Add a delay to prevent multiple spawns of the localstorage cookie
-  private static onTabUpdateDelay = false;
+  protected static onTabUpdateDelay = false;
 
-  private static tabToDomain: { [key: number]: string } = {};
+  protected static tabToDomain: { [key: number]: string } = {};
 }

--- a/src/typings/Cleanup.d.ts
+++ b/src/typings/Cleanup.d.ts
@@ -14,7 +14,7 @@
 interface CleanupProperties {
   greyCleanup: boolean;
   ignoreOpenTabs: boolean;
-};
+}
 
 type ActivityLog = {
   dateTime: string;

--- a/src/ui/popup/index.tsx
+++ b/src/ui/popup/index.tsx
@@ -1,3 +1,5 @@
+/* istanbul ignore file: React-redux init */
+
 /**
  * Copyright (c) 2017-2020 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
@@ -10,7 +12,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-/* istanbul ignore file: React-redux init */
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,8 @@
       "node_modules/web-ext-types",
       "src/typings"
     ],
-    "esModuleInterop": true,
+    "esModuleInterop": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
- Enhancements to TabEvents to make it slightly easier for coverage.
- Minor enhancement to AlarmEvents so that we can use jest.spyOn.
- Minor enhancement to BrowserActionService to include a check and to use proper camelCase in a function.
- Removed a semi-colon in an interface in Cleanup.d.ts.
- Removed unnecessary continue from CleanupService.spec.ts
- Fix typo in setup.js and simplified functions.

Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>