### PR TITLE
Fix Cookie Restore missing attributes.

### DIFF
--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -585,7 +585,7 @@ export const cleanCookiesOperation = async (
   }
 
   // Scrub private cookieStores
-  const storesIdsToScrub = ['firefox-private', 'private'];
+  const storesIdsToScrub = ['firefox-private', 'private', '1'];
   for (const id of storesIdsToScrub) {
     delete cachedResults.storeIds[id];
   }

--- a/src/ui/common_components/ActivityTable.tsx
+++ b/src/ui/common_components/ActivityTable.tsx
@@ -98,6 +98,7 @@ const returnReasonMessages = (cleanReasonObject: CleanReasonObject) => {
 };
 
 type ActivityAction = (log: ActivityLog) => void;
+
 interface StateProps {
   activityLog: ReadonlyArray<ActivityLog>;
   cache: CacheMap;

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -15,6 +15,7 @@
         "Fixed:  Internal Icons are now hidden as they cannot be shown (favIconUrl starting with 'chrome:'). This hides the error shown in console.",
         "Fixed:  Greyscale Icon now shows up at browser startup.",
         "Fixed:  CAD no longer removes items from containers if container cleaning is not enabled.  Closes #746.",
+        "Fixed:  Cookie names starting with __Host- or __Secure- may not have been restored correctly.  Closes #772.",
         "Updated:  Translations from Crowdin."
       ]
     },


### PR DESCRIPTION
Add in domain and secure attributes when restoring cookies.  Should fix #772.

Also fixes a typo.

Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>