### PR TITLE
Tooltip link rel + setting popup containers

### DIFF
--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -24,6 +24,10 @@ import {
   globExpressionToRegExp,
   isAnIP,
   isAWebpage,
+  isChrome,
+  isFirefox,
+  isFirefoxAndroid,
+  isFirefoxNotAndroid,
   isFirstPartyIsolate,
   localFileToRegex,
   parseCookieStoreId,
@@ -59,20 +63,18 @@ describe('Library Functions', () => {
         .mockReturnValue({ version: '0.12.34' });
     });
 
-    const origDebug = console.debug;
-    const origError = console.error;
-    const origInfo = console.info;
-    // tslint:disable-next-line:no-console
-    const origLog = console.log;
-    const origWarn = console.warn;
+    const origDebug = console.debug; // eslint-disable-line no-console
+    const origError = console.error; // eslint-disable-line no-console
+    const origInfo = console.info; // eslint-disable-line no-console
+    const origLog = console.log; // eslint-disable-line no-console
+    const origWarn = console.warn; // eslint-disable-line no-console
 
     afterEach(() => {
-      console.debug = origDebug;
-      console.error = origError;
-      console.info = origInfo;
-      // tslint:disable-next-line:no-console
-      console.log = origLog;
-      console.warn = origWarn;
+      console.debug = origDebug; // eslint-disable-line no-console
+      console.error = origError; // eslint-disable-line no-console
+      console.info = origInfo; // eslint-disable-line no-console
+      console.log = origLog; // eslint-disable-line no-console
+      console.warn = origWarn; // eslint-disable-line no-console
     });
 
     const consoleOutput = [] as { type: string; msg: string }[];
@@ -87,12 +89,11 @@ describe('Library Functions', () => {
       consoleOutput.push({ type: 'warn', msg });
 
     beforeEach(() => {
-      console.debug = mockedDebug;
-      console.error = mockedError;
-      console.info = mockedInfo;
-      // tslint:disable-next-line:no-console
-      console.log = mockedLog;
-      console.warn = mockedWarn;
+      console.debug = mockedDebug; // eslint-disable-line no-console
+      console.error = mockedError; // eslint-disable-line no-console
+      console.info = mockedInfo; // eslint-disable-line no-console
+      console.log = mockedLog; // eslint-disable-line no-console
+      console.warn = mockedWarn; // eslint-disable-line no-console
       consoleOutput.length = 0;
     });
 
@@ -664,6 +665,65 @@ describe('Library Functions', () => {
     });
   });
 
+  describe('isChrome()', () => {
+    it('should return false if browserDetect is undefined', () => {
+      expect(isChrome({})).toBe(false);
+    });
+    it('should return false if browserDetect is not Chrome', () => {
+      expect(isChrome({ browserDetect: 'test' })).toBe(false);
+    });
+    it('should return true if browserDetect is Chrome', () => {
+      expect(isChrome({ browserDetect: 'Chrome' })).toBe(true);
+    });
+  });
+
+  describe('isFirefox()', () => {
+    it('should return false if browserDetect is undefined', () => {
+      expect(isFirefox({})).toBe(false);
+    });
+    it('should return false if browserDetect is not Firefox', () => {
+      expect(isFirefox({ browserDetect: 'test' })).toBe(false);
+    });
+    it('should return true if browserDetect is Firefox', () => {
+      expect(isFirefox({ browserDetect: 'Firefox' })).toBe(true);
+    });
+  });
+
+  describe('isFirefoxAndroid()', () => {
+    it('should return false if platformOs is undefined', () => {
+      expect(isFirefoxAndroid({})).toBe(false);
+    });
+    it('should return false if platformOs is not android', () => {
+      expect(
+        isFirefoxAndroid({ browserDetect: 'test', platformOs: 'linux' }),
+      ).toBe(false);
+    });
+    it('should return true if platformOs is android', () => {
+      expect(
+        isFirefoxAndroid({ browserDetect: 'Firefox', platformOs: 'android' }),
+      ).toBe(true);
+    });
+  });
+
+  describe('isFirefoxNotAndroid()', () => {
+    it('should return false if platformOs is undefined', () => {
+      expect(isFirefoxNotAndroid({})).toBe(false);
+    });
+    it('should return true if platformOs is not android', () => {
+      expect(
+        isFirefoxNotAndroid({ browserDetect: 'Firefox', platformOs: 'linux' }),
+      ).toBe(true);
+    });
+    it('should return false if platformOs is android', () => {
+      expect(
+        isFirefoxNotAndroid({
+          browserDetect: 'Firefox',
+          platformOs: 'android',
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe('isFirstPartyIsolate()', () => {
     beforeEach(() => {
       when(global.browser.cookies.getAll)
@@ -826,7 +886,9 @@ describe('Library Functions', () => {
         'default',
         'expression.com',
       );
-      expect(results!.expression).toEqual('*.expression.com');
+      expect(results).toEqual(
+        expect.objectContaining({ expression: '*.expression.com' }),
+      );
     });
     it('should return undefined', () => {
       const results = returnMatchedExpressionObject(
@@ -858,7 +920,7 @@ describe('Library Functions', () => {
       expect(results).toEqual(
         expect.objectContaining({
           domain: 'example.com',
-          firstPartyDomain: null,
+          firstPartyDomain: undefined,
         }),
       );
     });

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -17,6 +17,8 @@ import {
   getHostname,
   getSetting,
   isAWebpage,
+  isChrome,
+  isFirefoxNotAndroid,
   isFirstPartyIsolate,
   LSCLEANUPNAME,
   prepareCleanupDomains,
@@ -410,9 +412,8 @@ export const otherBrowsingDataCleanup = async (
   const debug = getSetting(state, 'debugMode') as boolean;
   if (getSetting(state, 'localstorageCleanup')) {
     if (
-      state.cache.browserDetect === 'Firefox' &&
-      state.cache.browserVersion >= '58' &&
-      state.cache.platformOs !== 'android'
+      isFirefoxNotAndroid(state.cache) &&
+      state.cache.browserVersion >= '58'
     ) {
       const cleanList: string[] = [];
       for (const domain of domains) {
@@ -448,7 +449,7 @@ export const otherBrowsingDataCleanup = async (
         });
       return true;
     }
-    if (state.cache.browserDetect === 'Chrome') {
+    if (isChrome(state.cache)) {
       const cleanList: string[] = [];
       for (const domain of domains) {
         for (const d of prepareCleanupDomains(domain)) {
@@ -607,6 +608,7 @@ export const cleanCookiesOperation = async (
       }
       break;
     case 'Chrome':
+    case 'Opera':
       cookieStoreIds.add('0');
       if (await browser.extension.isAllowedIncognitoAccess()) {
         cookieStoreIds.add('1');

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -21,21 +21,26 @@ export const LSCLEANUPNAME = 'CookieAutoDeleteLocalStorageCleanup';
 /**
  * Console Log Outputs - Mostly For Debugging
  */
-export const cadLog = (x: CADLogItem, output: boolean) => {
+export const cadLog = (x: CADLogItem, output: boolean): void => {
   if (!x.msg || x.msg.trim() === '') return;
   if (!output) return;
   const h = `CAD_${browser.runtime.getManifest().version}`;
   const cOut = [
+    // eslint-disable-next-line no-console
     console.debug,
+    // eslint-disable-next-line no-console
     console.error,
+    // eslint-disable-next-line no-console
     console.info,
-    // tslint:disable-next-line:no-console
+    // eslint-disable-next-line no-console
     console.log,
+    // eslint-disable-next-line no-console
     console.warn,
   ];
   const cTypes = ['debug', 'error', 'info', 'log', 'warn'];
   let type = (x.type || 'debug').toLowerCase();
   if (!cTypes.includes(type)) {
+    // eslint-disable-next-line no-console
     console.error(
       `${h} - Invalid Console Output Type given [ ${type} ].  Using [debug] instead.`,
     );
@@ -56,6 +61,7 @@ export const cadLog = (x: CADLogItem, output: boolean) => {
       data = JSON.stringify(x.x, null, 2);
       break;
     default:
+      // eslint-disable-next-line no-console
       console.warn(
         `${h} - Received unexpected typeof [ ${tx} ].  Attempting to display it...`,
       );
@@ -69,7 +75,9 @@ export const cadLog = (x: CADLogItem, output: boolean) => {
 /**
  * Create Partial Cookie info for debug
  */
-export const createPartialTabInfo = (tab: Partial<browser.tabs.Tab>) => {
+export const createPartialTabInfo = (
+  tab: Partial<browser.tabs.Tab>,
+): Partial<browser.tabs.Tab> => {
   return {
     cookieStoreId: tab.cookieStoreId,
     discarded: tab.discarded,
@@ -84,7 +92,7 @@ export const createPartialTabInfo = (tab: Partial<browser.tabs.Tab>) => {
 /**
  * Converts a version string to a number
  */
-export const convertVersionToNumber = (version?: string) => {
+export const convertVersionToNumber = (version?: string): number => {
   if (!version) return -1;
   return parseInt(version.replace(/[.]/g, ''), 10);
 };
@@ -94,7 +102,7 @@ export const convertVersionToNumber = (version?: string) => {
  *   - sub.sub.domain.com ==> domain.com
  * Local html directory/files will return itself
  */
-export const extractMainDomain = (domain: string) => {
+export const extractMainDomain = (domain: string): string => {
   if (domain === '') return '';
   // return itself if it is a local html file or IP Address.
   if (
@@ -143,7 +151,7 @@ export const extractMainDomain = (domain: string) => {
  *   - file:///home/user/documents/file.html ==> file:///home/user/documents
  *   - file:///D:/user/documents/file.html ==> file:///D:/user/documents
  */
-export const getHostname = (urlToGetHostName: string | undefined) => {
+export const getHostname = (urlToGetHostName: string | undefined): string => {
   if (!urlToGetHostName) {
     return '';
   }
@@ -171,24 +179,26 @@ export const getHostname = (urlToGetHostName: string | undefined) => {
 /**
  * Gets the value of the setting
  */
-export const getSetting = (state: State, settingName: string) =>
-  state.settings[settingName].value;
+export const getSetting = (
+  state: State,
+  settingName: string,
+): string | number | boolean => state.settings[settingName].value;
 
 /**
  * Gets a sanitized cookieStoreId
  */
-export const getStoreId = (state: State, storeId: string) => {
+export const getStoreId = (state: State, storeId: string): string => {
   if (
     storeId === 'firefox-default' ||
     (!getSetting(state, 'contextualIdentities') &&
       storeId !== 'firefox-private' &&
-      state.cache.browserDetect === 'Firefox') ||
-    (state.cache.browserDetect === 'Chrome' && storeId === '0') ||
+      isFirefox(state.cache)) ||
+    (isChrome(state.cache) && storeId === '0') ||
     (state.cache.browserDetect === 'Opera' && storeId === '0')
   ) {
     return 'default';
   }
-  if (state.cache.browserDetect === 'Chrome' && storeId === '1') {
+  if (isChrome(state.cache) && storeId === '1') {
     return 'private';
   }
 
@@ -198,7 +208,7 @@ export const getStoreId = (state: State, storeId: string) => {
 /**
  * Converts a expression to its regular expression equivalent
  */
-export const globExpressionToRegExp = (glob: string) => {
+export const globExpressionToRegExp = (glob: string): string => {
   const normalizedGlob = glob.trim();
   if (normalizedGlob.slice(0, 1) === '/' && normalizedGlob.slice(-1) === '/') {
     // Treat /str/ as regular exprssion str
@@ -216,14 +226,14 @@ export const globExpressionToRegExp = (glob: string) => {
     .replace(/\./g, '\\.')
     .replace(/\*/g, '.*')
     .replace(/\[/g, '\\[')
-    .replace(/\]/g, '\\]')
+    .replace(/]/g, '\\]')
     .replace(/\\/g, '\\')}$`;
 };
 
 /**
  * Returns true if it is an IP (v4 or v6)
  */
-export const isAnIP = (url: string | undefined) => {
+export const isAnIP = (url: string | undefined): boolean => {
   if (!url) {
     return false;
   }
@@ -234,26 +244,69 @@ export const isAnIP = (url: string | undefined) => {
 /**
  * Returns true if it is a webpage or a local file
  */
-export const isAWebpage = (URL: string | undefined) => {
+export const isAWebpage = (URL: string | undefined): boolean => {
   if (!URL) {
     return false;
   }
-  if (URL.match(/^http:/) || URL.match(/^https:/) || URL.match(/^file:/)) {
-    return true;
-  }
-  return false;
+  return !!(URL.match(/^http:/) || URL.match(/^https:/) || URL.match(/^file:/));
+};
+
+/**
+ * Test if browser is Chrome
+ * @param cache Cache containing browserDetect
+ */
+export const isChrome = (cache: CacheMap): boolean => {
+  return (
+    Object.prototype.hasOwnProperty.call(cache, 'browserDetect') &&
+    cache.browserDetect === 'Chrome'
+  );
+};
+
+/**
+ * Test if browser is Firefox (Desktop or Mobile/Android)
+ * @param cache Cache containing browserDetect
+ */
+export const isFirefox = (cache: CacheMap): boolean => {
+  return (
+    Object.prototype.hasOwnProperty.call(cache, 'browserDetect') &&
+    cache.browserDetect === 'Firefox'
+  );
+};
+
+/**
+ * Test if browser is Firefox Mobile/Android
+ * @param cache Cache containing browserDetect and platformOs
+ */
+export const isFirefoxAndroid = (cache: CacheMap): boolean => {
+  return (
+    isFirefox(cache) &&
+    Object.prototype.hasOwnProperty.call(cache, 'platformOs') &&
+    cache.platformOs === 'android'
+  );
+};
+
+/**
+ * Test if browser is Firefox but not Android/mobile version
+ * @param cache Cache containing browserDetect and platformOs
+ */
+export const isFirefoxNotAndroid = (cache: CacheMap): boolean => {
+  return (
+    isFirefox(cache) &&
+    Object.prototype.hasOwnProperty.call(cache, 'platformOs') &&
+    cache.platformOs !== 'android'
+  );
 };
 
 /**
  * Test for FirstPartyIsolation (Firefox).
  * Workaround for not needing Firefox 'Privacy' permission.
  */
-export const isFirstPartyIsolate = async () => {
+export const isFirstPartyIsolate = async (): Promise<boolean> => {
   return browser.cookies
     .getAll({
       domain: '',
     })
-    .then((r) => {
+    .then(() => {
       // No error = most likely not enabled.
       return Promise.resolve(false);
     })
@@ -266,7 +319,7 @@ export const isFirstPartyIsolate = async () => {
 /*
  * Checks if the hostname given is a local file
  */
-export const localFileToRegex = (hostname: string) => {
+export const localFileToRegex = (hostname: string): string => {
   if (hostname === '') return '';
   if (hostname.startsWith('file:') || hostname.indexOf('/') === 0) {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
@@ -281,7 +334,7 @@ export const localFileToRegex = (hostname: string) => {
 export const parseCookieStoreId = (
   contextualIdentities: boolean,
   cookieStoreId: string | undefined,
-) => {
+): string => {
   return !contextualIdentities ||
     (cookieStoreId && cookieStoreId === 'firefox-default')
     ? 'default'
@@ -291,7 +344,7 @@ export const parseCookieStoreId = (
 /**
  * Prepare Domains for all cleanups.
  */
-export const prepareCleanupDomains = (domain: string) => {
+export const prepareCleanupDomains = (domain: string): string[] => {
   if (domain.trim() === '') return [];
   const www = new RegExp(/^www[0-9a-z]?\./i);
   const sDot = new RegExp(/^\./);
@@ -316,7 +369,7 @@ export const prepareCleanupDomains = (domain: string) => {
 /**
  * Puts the domain in the right format for browser.cookies.remove()
  */
-export const prepareCookieDomain = (cookie: browser.cookies.Cookie) => {
+export const prepareCookieDomain = (cookie: browser.cookies.Cookie): string => {
   let cookieDomain = cookie.domain.trim();
   if (cookieDomain.length === 0 && cookie.path.trim().length !== 0) {
     // No Domain - presuming local file (file:// protocol)
@@ -341,7 +394,7 @@ export const returnMatchedExpressionObject = (
   state: State,
   cookieStoreId: string,
   hostname: string,
-) => {
+): Expression | undefined => {
   const storeId = getStoreId(state, cookieStoreId);
   const expressionList = state.lists[storeId] || [];
   return expressionList.find((expression) =>
@@ -358,10 +411,10 @@ export const returnOptionalCookieAPIAttributes = (
     [x: string]: any;
   },
   firstPartyIsolate: boolean,
-) => {
+): Partial<CookiePropertiesCleanup> => {
   // Add optional firstPartyDomain attribute
   if (
-    state.cache.browserDetect === 'Firefox' &&
+    isFirefox(state.cache) &&
     firstPartyIsolate &&
     !Object.prototype.hasOwnProperty.call(
       cookieAPIAttributes,
@@ -370,10 +423,11 @@ export const returnOptionalCookieAPIAttributes = (
   ) {
     return {
       ...cookieAPIAttributes,
-      firstPartyDomain: null,
+      firstPartyDomain: undefined,
     };
   }
-  if (!(state.cache.browserDetect === 'Firefox' && firstPartyIsolate)) {
+  if (!(isFirefox(state.cache) && firstPartyIsolate)) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { firstPartyDomain, ...rest } = cookieAPIAttributes;
     return rest;
   }
@@ -387,7 +441,7 @@ export const showNotification = (x: {
   duration: number;
   msg: string;
   title?: string;
-}) => {
+}): void => {
   const sid = `manual-${shortid.generate()}`;
   browser.notifications.create(sid, {
     iconUrl: browser.runtime.getURL('icons/icon_48.png'),
@@ -407,7 +461,7 @@ export const showNotification = (x: {
  * Ensures no 0 second setTimeout otherwise side effects.
  * Ensures we don't go over max signed 32-bit Int of 2,147,483,647
  */
-export const sleep = (ms: number) => {
+export const sleep = (ms: number): Promise<any> => {
   return new Promise((r) =>
     setTimeout(r, ms < 250 ? 250 : ms > 2147483500 ? 2147483500 : ms),
   );
@@ -416,7 +470,7 @@ export const sleep = (ms: number) => {
 /**
  * Show an Error notification
  */
-export const throwErrorNotification = (e: Error) => {
+export const throwErrorNotification = (e: Error): void => {
   browser.notifications.create('failed-notification', {
     iconUrl: browser.runtime.getURL('icons/icon_red_48.png'),
     message: e.message,
@@ -428,12 +482,12 @@ export const throwErrorNotification = (e: Error) => {
 /**
  * Trim leading and ending dot of a string
  */
-export const trimDot = (str: string) => str.replace(/^[.]+|[.]+$/g, '');
+export const trimDot = (str: string): string => str.replace(/^[.]+|[.]+$/g, '');
 
 /**
  * Opposite of a falsey check for undefined
  */
-export const undefinedIsTrue = (bool: boolean | undefined) => {
+export const undefinedIsTrue = (bool: boolean | undefined): boolean => {
   if (bool === undefined) return true;
   return bool;
 };

--- a/src/ui/common_components/ExpressionOptions.tsx
+++ b/src/ui/common_components/ExpressionOptions.tsx
@@ -16,6 +16,9 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { updateExpressionUI } from '../../redux/Actions';
 import {
+  isChrome,
+  isFirefox,
+  isFirefoxNotAndroid,
   isFirstPartyIsolate,
   returnOptionalCookieAPIAttributes,
 } from '../../services/Libs';
@@ -68,11 +71,10 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
   }
   /** Converts an expression default storeId to the defaults of the browser */
   public toPublicStoreId(storeId: string) {
-    const browser: string = this.props.state.cache.browserDetect;
-    if (storeId === 'default' && browser === 'Chrome') {
+    if (storeId === 'default' && isChrome(this.props.state.cache)) {
       return '0';
     }
-    if (storeId === 'default' && browser === 'Firefox') {
+    if (storeId === 'default' && isFirefox(this.props.state.cache)) {
       return 'firefox-default';
     }
     return storeId;
@@ -82,7 +84,7 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
     const { expression } = this.props;
     const exp = expression.expression;
     const firstPartyIsolate = await isFirstPartyIsolate();
-    let cookies: browser.cookies.CookieProperties[] = [];
+    let cookies: browser.cookies.CookieProperties[];
     if (exp.startsWith('/') && exp.endsWith('/')) {
       // Treat expression as regular expression.  Get all cookies then regex domain.
       const allCookies = await browser.cookies.getAll(
@@ -172,7 +174,7 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
               role="checkbox"
               aria-checked={checked as boolean}
             />
-            <label htmlFor={key} area-labelledby={key}>
+            <label htmlFor={key} aria-labelledby={key}>
               {name}
             </label>
           </span>
@@ -210,10 +212,9 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
     return (
       <div>
         {!expression.expression.startsWith('file:') &&
-          ((state.cache.browserDetect === 'Firefox' &&
-            state.cache.browserVersion >= '57' &&
-            state.cache.platformOs !== 'android') ||
-            state.cache.browserDetect === 'Chrome') && (
+          ((isFirefoxNotAndroid(state.cache) &&
+            state.cache.browserVersion >= '57') ||
+            isChrome(state.cache)) && (
             <div className={'checkbox'}>
               <span
                 className={'addHover'}

--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -28,6 +28,8 @@ import {
   getHostname,
   getSetting,
   isAnIP,
+  isChrome,
+  isFirefoxNotAndroid,
   isFirstPartyIsolate,
   localFileToRegex,
   LSCLEANUPNAME,
@@ -68,7 +70,7 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
     document.documentElement.style.fontSize = `${
       (this.props.state.settings.sizePopup.value as number) || 16
     }px`;
-    if (this.props.state.cache.browserDetect === 'Chrome') {
+    if (isChrome(this.props.state.cache)) {
       // Chrome requires min width otherwise the layout is messed up
       document.documentElement.style.minWidth = `${
         430 +
@@ -176,6 +178,12 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
           }
         });
         this.port.onDisconnect.addListener((p) => {
+          if (p.error) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `Disconnected due to an error: ${browser.runtime.lastError}`,
+            );
+          }
           this.port = null;
         });
       }
@@ -362,12 +370,7 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
             iconName="cog"
             className="btn-info"
             onClick={() => {
-              if (
-                cache.browserDetect &&
-                cache.browserDetect === 'Firefox' &&
-                cache.platformOs &&
-                cache.platformOs !== 'android'
-              ) {
+              if (isFirefoxNotAndroid(cache)) {
                 browser.tabs.create({
                   cookieStoreId: tab.cookieStoreId,
                   index: tab.index + 1,
@@ -395,6 +398,7 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
         >
           {tab.favIconUrl && !tab.favIconUrl.startsWith('chrome:') && (
             <img
+              alt={'favIcon'}
               src={tab.favIconUrl}
               style={{
                 height: '20px',

--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -362,7 +362,13 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
             iconName="cog"
             className="btn-info"
             onClick={() => {
+              const isFFDesktop =
+                cache.browserDetect &&
+                cache.browserDetect === 'Firefox' &&
+                cache.platformOs &&
+                cache.platformOs !== 'android';
               browser.tabs.create({
+                cookieStoreId: isFFDesktop ? tab.cookieStoreId : undefined,
                 index: tab.index + 1,
                 url: '/settings/settings.html#tabSettings',
               });

--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -362,16 +362,23 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
             iconName="cog"
             className="btn-info"
             onClick={() => {
-              const isFFDesktop =
+              if (
                 cache.browserDetect &&
                 cache.browserDetect === 'Firefox' &&
                 cache.platformOs &&
-                cache.platformOs !== 'android';
-              browser.tabs.create({
-                cookieStoreId: isFFDesktop ? tab.cookieStoreId : undefined,
-                index: tab.index + 1,
-                url: '/settings/settings.html#tabSettings',
-              });
+                cache.platformOs !== 'android'
+              ) {
+                browser.tabs.create({
+                  cookieStoreId: tab.cookieStoreId,
+                  index: tab.index + 1,
+                  url: '/settings/settings.html#tabSettings',
+                });
+              } else {
+                browser.tabs.create({
+                  index: tab.index + 1,
+                  url: '/settings/settings.html#tabSettings',
+                });
+              }
               window.close();
             }}
             title={browser.i18n.getMessage('preferencesText')}

--- a/src/ui/popup/index.tsx
+++ b/src/ui/popup/index.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { createUIStore } from 'redux-webext';
-import { sleep } from '../../services/Libs';
+import { isChrome, sleep } from '../../services/Libs';
 import ErrorBoundary from '../common_components/ErrorBoundary';
 import fontAwesomeImports from '../font-awesome-imports';
 import App from './App';
@@ -32,8 +32,8 @@ async function initApp() {
   const mountNode = document.createElement('div');
   document.body.appendChild(mountNode);
 
-  if (browserDetect() === 'Chrome') {
-    await new Promise(resolve => setTimeout(resolve, 100));
+  if (isChrome(store.getState().cache)) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
   ReactDOM.render(

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -15,7 +15,12 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { resetSettings, updateSetting } from '../../../redux/Actions';
 import { initialState } from '../../../redux/State';
-import { cadLog } from '../../../services/Libs';
+import {
+  cadLog,
+  isChrome,
+  isFirefox,
+  isFirefoxNotAndroid,
+} from '../../../services/Libs';
 import { ReduxAction } from '../../../typings/ReduxConstants';
 import CheckboxSetting from '../../common_components/CheckboxSetting';
 import IconButton from '../../common_components/IconButton';
@@ -40,10 +45,8 @@ interface OwnProps {
 }
 
 interface StateProps {
+  cache: CacheMap;
   settings: MapToSettingObject;
-  browserDetect: string;
-  browserVersion: string;
-  platformOs: string;
 }
 
 interface DispatchProps {
@@ -195,11 +198,9 @@ class Settings extends React.Component<SettingProps> {
 
   public render() {
     const {
-      browserDetect,
-      browserVersion,
+      cache,
       onResetButtonClick,
       onUpdateSetting,
-      platformOs,
       settings,
       style,
     } = this.props;
@@ -388,7 +389,7 @@ class Settings extends React.Component<SettingProps> {
           <legend>
             {browser.i18n.getMessage('settingGroupOtherBrowsing')}
           </legend>
-          {browserDetect === 'Firefox' && platformOs !== 'android' && (
+          {isFirefoxNotAndroid(cache) && (
             <div className="form-group">
               <CheckboxSetting
                 text={browser.i18n.getMessage(
@@ -405,10 +406,8 @@ class Settings extends React.Component<SettingProps> {
               />
             </div>
           )}
-          {((browserDetect === 'Firefox' &&
-            browserVersion >= '58' &&
-            platformOs !== 'android') ||
-            browserDetect === 'Chrome') && (
+          {((isFirefoxNotAndroid(cache) && cache.browserVersion >= '58') ||
+            isChrome(cache)) && (
             <div className="form-group">
               <CheckboxSetting
                 text={`${browser.i18n.getMessage(
@@ -452,7 +451,7 @@ class Settings extends React.Component<SettingProps> {
               </div>
             )}
           </div>
-          {(browserDetect !== 'Firefox' || platformOs !== 'android') && (
+          {(!isFirefox(cache) || isFirefoxNotAndroid(cache)) && (
             <div className="form-group">
               <CheckboxSetting
                 text={browser.i18n.getMessage('showNumberOfCookiesInIconText')}
@@ -465,7 +464,7 @@ class Settings extends React.Component<SettingProps> {
               />
             </div>
           )}
-          {(browserDetect !== 'Firefox' || platformOs !== 'android') &&
+          {(!isFirefox(cache) || isFirefoxNotAndroid(cache)) &&
             settings.showNumOfCookiesInIcon.value === true && (
               <div className="form-group">
                 <CheckboxSetting
@@ -539,8 +538,7 @@ class Settings extends React.Component<SettingProps> {
             />
             <SettingsTooltip hrefURL={'#size-of-setting'} />
           </div>
-          {((browserDetect === 'Firefox' && platformOs !== 'android') ||
-            browserDetect === 'Chrome') && (
+          {(isFirefoxNotAndroid(cache) || isChrome(cache)) && (
             <div className="form-group">
               <CheckboxSetting
                 text={browser.i18n.getMessage('enableContextMenus')}
@@ -551,8 +549,7 @@ class Settings extends React.Component<SettingProps> {
               <SettingsTooltip hrefURL={'#enable-context-menus'} />
             </div>
           )}
-          {((browserDetect === 'Firefox' && platformOs !== 'android') ||
-            browserDetect === 'Chrome') && (
+          {(isFirefoxNotAndroid(cache) || isChrome(cache)) && (
             <div className="form-group">
               <CheckboxSetting
                 text={browser.i18n.getMessage('debugMode')}
@@ -566,14 +563,13 @@ class Settings extends React.Component<SettingProps> {
                   <p>{browser.i18n.getMessage('openDebugMode')}</p>
                   <pre>
                     <b>
-                      {(browserDetect === 'Firefox' &&
+                      {(isFirefox(cache) &&
                         'about:devtools-toolbox?type=extension&id=') ||
-                        (browserDetect === 'Chrome' &&
-                          `chrome://extensions/?id=`)}
+                        (isChrome(cache) && `chrome://extensions/?id=`)}
                       {encodeURIComponent(browser.runtime.id)}
                     </b>
                   </pre>
-                  {browserDetect === 'Chrome' && (
+                  {isChrome(cache) && (
                     <p>{browser.i18n.getMessage('chromeDebugMode')}</p>
                   )}
                   <p>
@@ -598,9 +594,7 @@ class Settings extends React.Component<SettingProps> {
 const mapStateToProps = (state: State) => {
   const { settings, cache } = state;
   return {
-    browserDetect: cache.browserDetect,
-    browserVersion: cache.browserVersion,
-    platformOs: cache.platformOs,
+    cache,
     settings,
   };
 };

--- a/src/ui/settings/components/SettingsTooltip.tsx
+++ b/src/ui/settings/components/SettingsTooltip.tsx
@@ -23,7 +23,12 @@ const SettingsTooltip: React.FunctionComponent<OwnProps> = ({ hrefURL }) => {
     ? hrefURL
     : `https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/Documentation${hrefURL}`;
   return (
-    <a href={link} target="_blank" rel="noreferrer" className="tooltipCustom">
+    <a
+      href={link}
+      target="_blank"
+      rel="help noreferrer noopener"
+      className="tooltipCustom"
+    >
       <FontAwesomeIcon size={'lg'} icon={['far', 'question-circle']} />
     </a>
   );


### PR DESCRIPTION
- Add `help noopener` to `<a rel...> `
- Have Firefox Desktop open settings tab in the same container as where the popup was triggered.