### PR TITLE
Fixed Clean dropdown border

### DIFF
--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -300,6 +300,8 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
                 data-disabled="true"
                 role="menu"
                 style={{
+                  borderBottomLeftRadius: 0,
+                  borderTopLeftRadius: 0,
                   transform: 'translate3d(-3px, 0px, 0px)',
                 }}
               >


### PR DESCRIPTION
# Problem

The button doesn't look very neat.

![Rounded corners on clean buttons dropdown](https://user-images.githubusercontent.com/28629647/86356270-789fb600-bc5b-11ea-9813-f1be73ed0d02.png)

# Fix

I fixed it so that in the popup, the clean dropdown menu button has no rounded corners.

It now looks like this:
![Not rounded corners on clean buttons dropdown](https://user-images.githubusercontent.com/28629647/86356272-79d0e300-bc5b-11ea-858f-ee2eb6ef2806.png)

Compare this to the [dropdowns on Bootstraps official documentation](https://getbootstrap.com/docs/4.0/components/dropdowns/):

![Dropdown on bootstraps documentation](https://user-images.githubusercontent.com/28629647/86356476-d6cc9900-bc5b-11ea-9b9e-3d2d4fcba8e4.png)

# Potential new fix / commit
There is one benefit with the unrounded corners, and that is that it's very obvious that the menu is a separate thing from the actual button. On GitHub, they solve this by adding a border:
![GitHub dropdown button](https://user-images.githubusercontent.com/28629647/86356611-12fff980-bc5c-11ea-9450-3ca9b57593c0.png)

If you would like, I could add such a border that would look like this:

![Border dividing dropdown menu](https://user-images.githubusercontent.com/28629647/86356735-43e02e80-bc5c-11ea-98c4-a3f9b3824d29.png)

To add this, I would simply add a color to the left border.

```
borderLeftColor: '#c69500',
```