### PR TITLE
Fix help link for Keep Default Icon on all list types

### DIFF
--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -473,7 +473,7 @@ class Settings extends React.Component<SettingProps> {
                   inline={true}
                   updateSetting={(payload) => onUpdateSetting(payload)}
                 />
-                <SettingsTooltip hrefURL={'#keep-default-icon'} />
+                <SettingsTooltip hrefURL={'#keep-default-icon-on-all-list-types'} />
               </div>
             )}
           <div className="form-group">


### PR DESCRIPTION
The new one seems to work:
https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/Documentation#keep-default-icon-on-all-list-types