### PR TITLE
feat: Summary notifications

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -919,6 +919,10 @@
     "message": "Show Number of Cookies for that Domain over the Icon",
     "description": "Show Number of Cookies for that Domain over the Icon"
   },
+  "siteDataText": {
+    "message": "Site Data",
+    "description": "Site Data.  Found in Activity Log Summary and Notifications."
+  },
   "sizePopupText": {
     "message": "Size of Popup (in px)",
     "description": "Size of Popup (in px).  This sets the font size in the Popup."

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -22,7 +22,6 @@ import {
   isChrome,
   isFirefoxAndroid,
   showNotification,
-  siteDataToBrowser,
   sleep,
 } from '../services/Libs';
 import {
@@ -379,20 +378,23 @@ export const cookieCleanup: ActionCreator<ThunkAction<
       });
       await sleep(750);
     }
+    // Here we just show a generic 'Site Data' cleaned instead of the specifics, with all domains.
     if (siteDataCleaned && browsingDataCleanup) {
-      Object.entries(browsingDataCleanup).map(async ([siteData, domains]) => {
+      const domainsAll: string[] = [];
+      for (const domains of Object.values(browsingDataCleanup)) {
         if (!domains || domains.length === 0) return;
+        domainsAll.push(...domains);
+      }
+      if (domainsAll.length > 0) {
         await showNotification({
           duration: getSetting(getState(), 'notificationOnScreen') as number,
           msg: browser.i18n.getMessage('activityLogSiteDataDomainsText', [
-            browser.i18n.getMessage(
-              `${siteDataToBrowser(siteData as SiteDataType)}Text`,
-            ),
-            domains.join(', '),
+            browser.i18n.getMessage('siteDataText'),
+            domainsAll.join(', '),
           ]),
           title: browser.i18n.getMessage('notificationTitleSiteData'),
         });
-      });
+      }
     }
   }
 };

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -456,6 +456,7 @@ export const clearSiteDataForThisDomain = async (
   );
   const domains = prepareCleanupDomains(hostname, state.cache.browserDetect);
   if (siteData === 'All') {
+    const siteDataAll: string[] = [];
     for (const sd of SITEDATATYPES) {
       await removeSiteData(
         state,
@@ -463,9 +464,22 @@ export const clearSiteDataForThisDomain = async (
         state.cache.browserDetect,
         domains,
         debug,
-        true,
+        false,
       );
+      siteDataAll.push(browser.i18n.getMessage(`${siteDataToBrowser(sd)}Text`));
     }
+    // To consolidate the notification shown, we do it out here.
+    showNotification(
+      {
+        duration: getSetting(state, 'notificationOnScreen') as number,
+        msg: browser.i18n.getMessage('activityLogSiteDataDomainsText', [
+          siteDataAll.join(', '),
+          domains.join(', '),
+        ]),
+        title: browser.i18n.getMessage('notificationTitleSiteData'),
+      },
+      getSetting(state, 'manualNotifications') as boolean,
+    );
   } else {
     await removeSiteData(
       state,

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -33,7 +33,6 @@ import {
   trimDot,
   undefinedIsTrue,
 } from './Libs';
-import ActivityLog from '../ui/settings/components/ActivityLog';
 
 /** Prepare a cookie for deletion */
 export const prepareCookie = (
@@ -778,7 +777,7 @@ export const cleanCookiesOperation = async (
   const debug = getSetting(state, 'debugMode') as boolean;
   const deletedSiteDataArrays: ActivityLog['browsingDataCleanup'] = {};
   const setOfDeletedDomainCookies = new Set<string>();
-  const cachedResults: ActivityLog = {
+  const cachedResults: Required<ActivityLog> = {
     dateTime: new Date().toString(),
     recentlyCleaned: 0,
     storeIds: {},
@@ -975,12 +974,10 @@ export const cleanCookiesOperation = async (
     }
   }
 
-  if (cachedResults.browsingDataCleanup) {
-    for (const sd of SITEDATATYPES) {
-      cachedResults.browsingDataCleanup[sd] = deletedSiteDataArrays[sd]
-        ? Array.from(new Set(deletedSiteDataArrays[sd] as string[]))
-        : [];
-    }
+  for (const sd of SITEDATATYPES) {
+    cachedResults.browsingDataCleanup[sd] = deletedSiteDataArrays[sd]
+      ? Array.from(new Set(deletedSiteDataArrays[sd] as string[]))
+      : [];
   }
 
   for (const id of storesIdsToScrub) {

--- a/src/services/StoreUser.ts
+++ b/src/services/StoreUser.ts
@@ -16,7 +16,7 @@ import { Store } from 'redux';
 import { ReduxAction } from '../typings/ReduxConstants';
 
 export default class StoreUser {
-  public static init(store: Store) {
+  public static init(store: Store): void {
     StoreUser.store = store;
   }
   protected static store: Store<State, ReduxAction>;

--- a/src/ui/UILibs.tsx
+++ b/src/ui/UILibs.tsx
@@ -10,8 +10,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-// Dynamically generate timestamp as a string
-export const appendDynamicTimestamp = () => {
+
+/**
+ *  Dynamically generate timestamp as a string
+ */
+export const appendDynamicTimestamp = (): string => {
   // We take into account the timezone offset since using Date.toISOString() returns in UTC/GMT.
   return new Date(new Date().getTime() - new Date().getTimezoneOffset() * 60000)
     .toISOString()
@@ -20,12 +23,14 @@ export const appendDynamicTimestamp = () => {
     .replace(/:/g, '.');
 };
 
-// Dynamically generate data to be downloaded and executes the download.
-// https://stackoverflow.com/questions/19721439/download-json-object-as-a-file-from-browser
+/**
+ * Dynamically generate data to be downloaded and executes the download.
+ * https://stackoverflow.com/questions/19721439/download-json-object-as-a-file-from-browser
+ */
 export const downloadObjectAsJSON = (
   exportObj: Record<string, unknown>,
   exportName = 'ExportedData',
-) => {
+): Record<string, boolean | null | string> => {
   const dataHref = `data:text/json;charset=urf-8,${encodeURIComponent(
     JSON.stringify(exportObj, null, 2),
   )}`;

--- a/src/ui/settings/components/SideBar.tsx
+++ b/src/ui/settings/components/SideBar.tsx
@@ -48,7 +48,7 @@ interface OwnProps {
 
 class SideBar extends React.Component<OwnProps> {
   // Switches tabs
-  public toggleClass(element: HTMLElement | null, className: string) {
+  public toggleClass(element: HTMLElement | null, className: string): void {
     if (!element) return;
     const classes = element.className.split(/\s+/);
     const length = classes.length;
@@ -68,7 +68,7 @@ class SideBar extends React.Component<OwnProps> {
   }
 
   // Toggles the sidebar
-  public toggleAll() {
+  public toggleAll(): void {
     const active = 'active';
     const layout = document.getElementById('layout');
     const menu = document.getElementById('menu');
@@ -77,7 +77,7 @@ class SideBar extends React.Component<OwnProps> {
     this.toggleClass(menu, active);
     this.toggleClass(menuLink, active);
   }
-  public render() {
+  public render(): React.ReactNode {
     const { activeTab, switchTabs } = this.props;
     return (
       <div>
@@ -100,7 +100,7 @@ class SideBar extends React.Component<OwnProps> {
               <br />
               <b>{browser.runtime.getManifest().version}</b>
             </div>
-            {sideBarTabs.map((element, index) => (
+            {sideBarTabs.map((element) => (
               <div
                 key={element.tabId}
                 id={`${element.tabId}`}


### PR DESCRIPTION
This consolidates site data notifications.

For autoclean notifications, it has been generalized to 'Invoked cleanup of site data for <domains>'
For manual notifications, it will still show individual site data cleanup, or if 'all' was used, then all site data cleanups (minus cookies as that has its own notification) will be combined (i.e. 'Invoked cleanup of Cache, IndexedDB, ... for <domain>).

This also fixes the eslint warnings about missing return types.

A minor patch to the option browserDataCleanup object in Activity Log - Only make it required when creating new ActivityLog Object from autoclean triggers.