### PR TITLE
Implement ContextualIdentityService and eventListenerActions

### DIFF
--- a/__tests__/redux/Reducer.spec.ts
+++ b/__tests__/redux/Reducer.spec.ts
@@ -487,13 +487,16 @@ describe('Reducer', () => {
     it('should update settings accordingly', () => {
       const newState = settings(initialState.settings, {
         payload: {
-          name: 'activeMode',
+          name: `${SettingID.ACTIVE_MODE}`,
           value: true,
         },
         type: ReduxConstants.UPDATE_SETTING,
       });
-      expect(newState['activeMode']).toEqual(
-        expect.objectContaining({ name: 'activeMode', value: true }),
+      expect(newState[`${SettingID.ACTIVE_MODE}`]).toEqual(
+        expect.objectContaining({
+          name: `${SettingID.ACTIVE_MODE}`,
+          value: true,
+        }),
       );
     });
     it('should reset settings to initial via RESET_ALL', () => {
@@ -501,7 +504,7 @@ describe('Reducer', () => {
         {
           ...initialState.settings,
           activeMode: {
-            name: 'activeMode',
+            name: `${SettingID.ACTIVE_MODE}`,
             value: true,
           },
         },
@@ -516,7 +519,7 @@ describe('Reducer', () => {
         {
           ...initialState.settings,
           activeMode: {
-            name: 'activeMode',
+            name: `${SettingID.ACTIVE_MODE}`,
             value: true,
           },
         },

--- a/__tests__/redux/Reducer.spec.ts
+++ b/__tests__/redux/Reducer.spec.ts
@@ -503,7 +503,7 @@ describe('Reducer', () => {
       const newState = settings(
         {
           ...initialState.settings,
-          activeMode: {
+          [`${SettingID.ACTIVE_MODE}`]: {
             name: `${SettingID.ACTIVE_MODE}`,
             value: true,
           },
@@ -518,7 +518,7 @@ describe('Reducer', () => {
       const newState = settings(
         {
           ...initialState.settings,
-          activeMode: {
+          [`${SettingID.ACTIVE_MODE}`]: {
             name: `${SettingID.ACTIVE_MODE}`,
             value: true,
           },

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -326,7 +326,7 @@ describe('CleanupService', () => {
         settings: {
           ...firefoxState.settings,
           debugMode: {
-            name: 'debugMode',
+            name: `${SettingID.DEBUG_MODE}`,
             value: true,
           },
         },
@@ -505,7 +505,7 @@ describe('CleanupService', () => {
             settings: {
               ...firefoxState.settings,
               cacheCleanup: {
-                name: 'cacheCleanup',
+                name: `${SettingID.CLEANUP_CACHE}`,
                 value: true,
               },
             },
@@ -540,7 +540,7 @@ describe('CleanupService', () => {
           settings: {
             ...firefoxState.settings,
             contextualIdentities: {
-              name: 'contextualIdentities',
+              name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
               value: true,
             },
           },
@@ -558,7 +558,7 @@ describe('CleanupService', () => {
             settings: {
               ...firefoxState.settings,
               cacheCleanup: {
-                name: 'cacheCleanup',
+                name: `${SettingID.CLEANUP_CACHE}`,
                 value: true,
               },
             },
@@ -581,7 +581,7 @@ describe('CleanupService', () => {
             settings: {
               ...firefoxState.settings,
               indexedDBCleanup: {
-                name: 'indexedDBCleanup',
+                name: `${SettingID.CLEANUP_INDEXEDDB}`,
                 value: true,
               },
             },
@@ -604,7 +604,7 @@ describe('CleanupService', () => {
             settings: {
               ...firefoxState.settings,
               localStorageCleanup: {
-                name: 'localStorageCleanup',
+                name: `${SettingID.CLEANUP_LOCALSTORAGE}`,
                 value: true,
               },
             },
@@ -622,7 +622,7 @@ describe('CleanupService', () => {
             settings: {
               ...firefoxState.settings,
               pluginDataCleanup: {
-                name: 'pluginDataCleanup',
+                name: `${SettingID.CLEANUP_PLUGIN_DATA}`,
                 value: true,
               },
             },
@@ -644,7 +644,7 @@ describe('CleanupService', () => {
             settings: {
               ...firefoxState.settings,
               serviceWorkersCleanup: {
-                name: 'serviceWorkersCleanup',
+                name: `${SettingID.CLEANUP_SERVICE_WORKERS}`,
                 value: true,
               },
             },
@@ -1059,7 +1059,7 @@ describe('CleanupService', () => {
       settings: {
         ...sampleState.settings,
         cleanExpiredCookies: {
-          name: 'cleanExpiredCookies',
+          name: `${SettingID.CLEAN_EXPIRED}`,
           value: true,
         },
       },
@@ -1416,7 +1416,7 @@ describe('CleanupService', () => {
       settings: {
         ...initialState.settings,
         cacheCleanup: {
-          name: 'cacheCleanup',
+          name: `${SettingID.CLEANUP_CACHE}`,
           value: true,
         },
       },
@@ -1426,7 +1426,7 @@ describe('CleanupService', () => {
       settings: {
         ...initialState.settings,
         indexedDBCleanup: {
-          name: 'indexedDBCleanup',
+          name: `${SettingID.CLEANUP_INDEXEDDB}`,
           value: true,
         },
       },
@@ -1436,7 +1436,7 @@ describe('CleanupService', () => {
       settings: {
         ...initialState.settings,
         localStorageCleanup: {
-          name: 'localStorageCleanup',
+          name: `${SettingID.CLEANUP_LOCALSTORAGE}`,
           value: true,
         },
       },
@@ -1446,7 +1446,7 @@ describe('CleanupService', () => {
       settings: {
         ...initialState.settings,
         pluginDataCleanup: {
-          name: 'pluginDataCleanup',
+          name: `${SettingID.CLEANUP_PLUGIN_DATA}`,
           value: true,
         },
       },
@@ -1456,7 +1456,7 @@ describe('CleanupService', () => {
       settings: {
         ...initialState.settings,
         serviceWorkersCleanup: {
-          name: 'serviceWorkersCleanup',
+          name: `${SettingID.CLEANUP_SERVICE_WORKERS}`,
           value: true,
         },
       },

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -325,7 +325,7 @@ describe('CleanupService', () => {
         ...firefoxState,
         settings: {
           ...firefoxState.settings,
-          debugMode: {
+          [`${SettingID.DEBUG_MODE}`]: {
             name: `${SettingID.DEBUG_MODE}`,
             value: true,
           },
@@ -504,7 +504,7 @@ describe('CleanupService', () => {
             ...firefoxState,
             settings: {
               ...firefoxState.settings,
-              cacheCleanup: {
+              [`${SettingID.CLEANUP_CACHE}`]: {
                 name: `${SettingID.CLEANUP_CACHE}`,
                 value: true,
               },
@@ -539,7 +539,7 @@ describe('CleanupService', () => {
           ...firefoxState,
           settings: {
             ...firefoxState.settings,
-            contextualIdentities: {
+            [`${SettingID.CONTEXTUAL_IDENTITIES}`]: {
               name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
               value: true,
             },
@@ -557,7 +557,7 @@ describe('CleanupService', () => {
             ...firefoxState,
             settings: {
               ...firefoxState.settings,
-              cacheCleanup: {
+              [`${SettingID.CLEANUP_CACHE}`]: {
                 name: `${SettingID.CLEANUP_CACHE}`,
                 value: true,
               },
@@ -580,7 +580,7 @@ describe('CleanupService', () => {
             ...firefoxState,
             settings: {
               ...firefoxState.settings,
-              indexedDBCleanup: {
+              [`${SettingID.CLEANUP_INDEXEDDB}`]: {
                 name: `${SettingID.CLEANUP_INDEXEDDB}`,
                 value: true,
               },
@@ -603,7 +603,7 @@ describe('CleanupService', () => {
             ...firefoxState,
             settings: {
               ...firefoxState.settings,
-              localStorageCleanup: {
+              [`${SettingID.CLEANUP_LOCALSTORAGE}`]: {
                 name: `${SettingID.CLEANUP_LOCALSTORAGE}`,
                 value: true,
               },
@@ -621,7 +621,7 @@ describe('CleanupService', () => {
             ...firefoxState,
             settings: {
               ...firefoxState.settings,
-              pluginDataCleanup: {
+              [`${SettingID.CLEANUP_PLUGIN_DATA}`]: {
                 name: `${SettingID.CLEANUP_PLUGIN_DATA}`,
                 value: true,
               },
@@ -643,7 +643,7 @@ describe('CleanupService', () => {
             ...firefoxState,
             settings: {
               ...firefoxState.settings,
-              serviceWorkersCleanup: {
+              [`${SettingID.CLEANUP_SERVICE_WORKERS}`]: {
                 name: `${SettingID.CLEANUP_SERVICE_WORKERS}`,
                 value: true,
               },
@@ -1058,7 +1058,7 @@ describe('CleanupService', () => {
       ...sampleState,
       settings: {
         ...sampleState.settings,
-        cleanExpiredCookies: {
+        [`${SettingID.CLEAN_EXPIRED}`]: {
           name: `${SettingID.CLEAN_EXPIRED}`,
           value: true,
         },
@@ -1415,7 +1415,7 @@ describe('CleanupService', () => {
       ...ffState,
       settings: {
         ...initialState.settings,
-        cacheCleanup: {
+        [`${SettingID.CLEANUP_CACHE}`]: {
           name: `${SettingID.CLEANUP_CACHE}`,
           value: true,
         },
@@ -1425,7 +1425,7 @@ describe('CleanupService', () => {
       ...ffState,
       settings: {
         ...initialState.settings,
-        indexedDBCleanup: {
+        [`${SettingID.CLEANUP_INDEXEDDB}`]: {
           name: `${SettingID.CLEANUP_INDEXEDDB}`,
           value: true,
         },
@@ -1435,7 +1435,7 @@ describe('CleanupService', () => {
       ...ffState,
       settings: {
         ...initialState.settings,
-        localStorageCleanup: {
+        [`${SettingID.CLEANUP_LOCALSTORAGE}`]: {
           name: `${SettingID.CLEANUP_LOCALSTORAGE}`,
           value: true,
         },
@@ -1445,7 +1445,7 @@ describe('CleanupService', () => {
       ...ffState,
       settings: {
         ...initialState.settings,
-        pluginDataCleanup: {
+        [`${SettingID.CLEANUP_PLUGIN_DATA}`]: {
           name: `${SettingID.CLEANUP_PLUGIN_DATA}`,
           value: true,
         },
@@ -1455,7 +1455,7 @@ describe('CleanupService', () => {
       ...ffState,
       settings: {
         ...initialState.settings,
-        serviceWorkersCleanup: {
+        [`${SettingID.CLEANUP_SERVICE_WORKERS}`]: {
           name: `${SettingID.CLEANUP_SERVICE_WORKERS}`,
           value: true,
         },

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -20,14 +20,12 @@ jest.requireActual('../../src/services/Libs');
 import * as Lib from '../../src/services/Libs';
 
 // This dynamically generates the spies for all functions in Libs
-const spyLib: { [s: string]: jest.SpyInstance } = global.generateSpies(Lib);
+const spyLib: JestSpyObject = global.generateSpies(Lib);
 
 jest.requireActual('../../src/services/CleanupService');
 import * as CleanupService from '../../src/services/CleanupService';
 import { CADCOOKIENAME } from '../../src/services/Libs';
-const spyCleanupService: {
-  [s: string]: jest.SpyInstance;
-} = global.generateSpies(CleanupService);
+const spyCleanupService: JestSpyObject = global.generateSpies(CleanupService);
 
 const sampleTab: browser.tabs.Tab = {
   active: true,

--- a/__tests__/services/ContextMenuEvents.spec.ts
+++ b/__tests__/services/ContextMenuEvents.spec.ts
@@ -134,7 +134,7 @@ describe('ContextMenuEvents', () => {
       global.browser.contextMenus = jestContextMenus;
     });
     it('should do nothing if contextMenus setting is disabled', () => {
-      TestStore.changeSetting('contextMenus', false);
+      TestStore.changeSetting(`${SettingID.CONTEXT_MENUS}`, false);
       ContextMenuEvents.menuInit();
       expect(global.browser.contextMenus.create).not.toHaveBeenCalled();
     });
@@ -142,7 +142,7 @@ describe('ContextMenuEvents', () => {
       when(global.browser.contextMenus.onClicked.hasListener)
         .calledWith(expect.any(Function))
         .mockReturnValue(false);
-      TestStore.changeSetting('contextMenus', true);
+      TestStore.changeSetting(`${SettingID.CONTEXT_MENUS}`, true);
       ContextMenuEvents.menuInit();
       expect(TestContextMenuEvents.getIsInitialized()).toBe(true);
       expect(global.browser.contextMenus.create).toHaveBeenCalledTimes(35);
@@ -154,7 +154,7 @@ describe('ContextMenuEvents', () => {
       when(global.browser.contextMenus.onClicked.hasListener)
         .calledWith(expect.any(Function))
         .mockReturnValue(true);
-      TestStore.changeSetting('contextMenus', true);
+      TestStore.changeSetting(`${SettingID.CONTEXT_MENUS}`, true);
       TestContextMenuEvents.setIsInitialized(false);
       ContextMenuEvents.menuInit();
       expect(
@@ -162,7 +162,7 @@ describe('ContextMenuEvents', () => {
       ).not.toHaveBeenCalled();
     });
     it('should do nothing if contextMenus setting is enabled and menus were already created', () => {
-      TestStore.changeSetting('contextMenus', true);
+      TestStore.changeSetting(`${SettingID.CONTEXT_MENUS}`, true);
       TestContextMenuEvents.setIsInitialized(true);
       ContextMenuEvents.menuInit();
       expect(global.browser.contextMenus.create).not.toHaveBeenCalled();
@@ -504,7 +504,7 @@ describe('ContextMenuEvents', () => {
       );
     });
     it('Trigger SELECT_ADD_GREY_DOMAIN and contextualIdentities was enabled', () => {
-      TestStore.changeSetting('contextualIdentities', true);
+      TestStore.changeSetting(`${SettingID.CONTEXTUAL_IDENTITIES}`, true);
       TestStore.addCache({
         key: 'firefox-container-1',
         value: 'Personal',
@@ -523,7 +523,7 @@ describe('ContextMenuEvents', () => {
       );
     });
     it('Trigger SELECT_ADD_GREY_DOMAIN and contextualIdentities was enabled with no matching container', () => {
-      TestStore.changeSetting('contextualIdentities', true);
+      TestStore.changeSetting(`${SettingID.CONTEXTUAL_IDENTITIES}`, true);
       ContextMenuEvents.onContextMenuClicked(
         {
           ...sampleClickText,
@@ -645,7 +645,7 @@ describe('ContextMenuEvents', () => {
         sampleTab,
       );
       expect(spyActions.updateSetting).toHaveBeenCalledWith({
-        name: 'activeMode',
+        name: `${SettingID.ACTIVE_MODE}`,
         value: true,
       });
     });

--- a/__tests__/services/ContextMenuEvents.spec.ts
+++ b/__tests__/services/ContextMenuEvents.spec.ts
@@ -25,17 +25,13 @@ import * as Lib from '../../src/services/Libs';
 import StoreUser from '../../src/services/StoreUser';
 
 jest.requireActual('../../src/redux/Actions');
-const spyActions: { [s: string]: jest.SpyInstance } = global.generateSpies(
-  Actions,
-);
+const spyActions: JestSpyObject = global.generateSpies(Actions);
 
 jest.requireMock('../../src/services/CleanupService');
-const spyCleanupService: {
-  [s: string]: jest.SpyInstance;
-} = global.generateSpies(CleanupService);
+const spyCleanupService: JestSpyObject = global.generateSpies(CleanupService);
 
 jest.requireActual('../../src/services/Libs');
-const spyLib: { [s: string]: jest.SpyInstance } = global.generateSpies(Lib);
+const spyLib: JestSpyObject = global.generateSpies(Lib);
 
 const store: Store<State, ReduxAction> = createStore(initialState);
 StoreUser.init(store);

--- a/__tests__/services/ContextualIdentitiesEvents.spec.ts
+++ b/__tests__/services/ContextualIdentitiesEvents.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2020 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { when } from 'jest-when';
+import { Store } from 'redux';
+
+import * as Actions from '../../src/redux/Actions';
+import { initialState } from '../../src/redux/State';
+// tslint:disable-next-line: import-name
+import createStore from '../../src/redux/Store';
+import { ReduxAction, ReduxConstants } from '../../src/typings/ReduxConstants';
+import ContextualIdentitiesEvents from '../../src/services/ContextualIdentitiesEvents';
+import * as Lib from '../../src/services/Libs';
+import StoreUser from '../../src/services/StoreUser';
+
+jest.requireActual('../../src/services/Libs');
+const spyLib: { [s: string]: jest.SpyInstance } = global.generateSpies(Lib);
+
+const store: Store<State, ReduxAction> = createStore(initialState);
+StoreUser.init(store);
+
+class TestStore extends StoreUser {
+  public static addCache(payload: any) {
+    StoreUser.store.dispatch({
+      payload,
+      type: ReduxConstants.ADD_CACHE,
+    });
+  }
+
+  public static getCacheValue(key: string) {
+    return StoreUser.store.getState().cache[key];
+  }
+
+  public static changeSetting(name: string, value: string | boolean | number) {
+    StoreUser.store.dispatch(Actions.updateSetting({ name, value }));
+  }
+
+  public static resetSetting() {
+    StoreUser.store.dispatch(Actions.resetSettings());
+  }
+}
+
+class TestContextualIdentitiesEvents extends ContextualIdentitiesEvents {
+  public static getIsInitialized() {
+    return ContextualIdentitiesEvents.isInitialized;
+  }
+  public static setIsInitialized(value: boolean) {
+    ContextualIdentitiesEvents.isInitialized = value;
+  }
+}
+
+const defaultContextualIdentity: browser.contextualIdentities.ContextualIdentity = {
+  cookieStoreId: 'firefox-container-0',
+  color: 'blue',
+  icon: 'fingerprint',
+  name: 'Testing Container',
+};
+
+describe('ContextualIdentitiesEvents', () => {
+  beforeAll(() => {
+    when(global.browser.runtime.getManifest)
+      .calledWith()
+      .mockReturnValue({ version: '0.12.34' } as never);
+    when(global.browser.contextualIdentities.query)
+      .calledWith({})
+      .mockResolvedValue([
+        defaultContextualIdentity,
+        { ...defaultContextualIdentity, cookieStoreId: 'firefox-container-1' },
+        { ...defaultContextualIdentity, cookieStoreId: 'firefox-container-99' },
+      ] as never);
+  });
+  afterEach(() => {
+    TestStore.resetSetting();
+  });
+
+  describe('init', () => {
+    it('should do nothing if browser.contextualIdentities do not exist', () => {
+      // Override setup of browser.contextualIdentities
+      const jestContextualIdentities = global.browser.contextualIdentities;
+      global.browser.contextualIdentities = undefined;
+      ContextualIdentitiesEvents.init();
+      expect(spyLib.getSetting).not.toHaveBeenCalled();
+      // Restore browser.contextualIdentities for future tests
+      global.browser.contextualIdentities = jestContextualIdentities;
+    });
+    it('should do nothing if contextualIdentities setting is false/disabled', () => {
+      TestStore.changeSetting(`${SettingID.CONTEXTUAL_IDENTITIES}`, false);
+      ContextualIdentitiesEvents.init();
+      expect(TestContextualIdentitiesEvents.getIsInitialized()).toEqual(false);
+    });
+    it('should populate cache with existing container maps and add listeners.', () => {
+      when(global.browser.contextualIdentities.onCreated.hasListener)
+        .calledWith(expect.any(Function))
+        .mockReturnValue(false);
+      TestStore.changeSetting(`${SettingID.CONTEXTUAL_IDENTITIES}`, true);
+      ContextualIdentitiesEvents.init();
+      expect(TestContextualIdentitiesEvents.getIsInitialized()).toEqual(true);
+      expect(spyLib.eventListenerActions).toHaveBeenCalledTimes(3);
+    });
+    it('should do nothing if contextualIdentities was already initialized', () => {
+      TestStore.changeSetting(SettingID.CONTEXTUAL_IDENTITIES, true);
+      ContextualIdentitiesEvents.init();
+      expect(spyLib.eventListenerActions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deInit()', () => {
+    it('should do nothing if it was not initialized previously', async () => {
+      TestContextualIdentitiesEvents.setIsInitialized(false);
+      await ContextualIdentitiesEvents.deInit();
+      expect(spyLib.eventListenerActions).not.toHaveBeenCalled();
+    });
+    it('should remove all listeners and existing containers in cache', async () => {
+      TestStore.addCache({
+        payload: {
+          key: 'firefox-container-99',
+          value: 'TestContainer',
+        },
+      });
+      when(global.browser.contextualIdentities.onCreated.hasListener)
+        .calledWith(expect.any(Function))
+        .mockReturnValue(true);
+      TestContextualIdentitiesEvents.setIsInitialized(true);
+      await ContextualIdentitiesEvents.deInit();
+      expect(spyLib.eventListenerActions).toHaveBeenCalledTimes(3);
+      expect(TestContextualIdentitiesEvents.getIsInitialized()).toEqual(false);
+      expect(TestStore.getCacheValue('firefox-container-99')).toBeUndefined();
+    });
+  });
+
+  describe('onContainerCreated()', () => {
+    it('should add the new container map into the cache', () => {
+      ContextualIdentitiesEvents.onContainerCreated({
+        contextualIdentity: {
+          ...defaultContextualIdentity,
+          cookieStoreId: 'new-container-1',
+        },
+      });
+      expect(TestStore.getCacheValue('new-container-1')).toEqual(
+        'Testing Container',
+      );
+    });
+  });
+
+  describe('onContainerRemoved()', () => {
+    it('should set undefined that cookieStoreId from cache', () => {
+      TestStore.addCache({
+        key: 'remove-container-1',
+        value: 'AShortLivedContainer',
+      });
+      ContextualIdentitiesEvents.onContainerRemoved({
+        contextualIdentity: {
+          ...defaultContextualIdentity,
+          cookieStoreId: 'remove-container-1',
+        },
+      });
+      expect(TestStore.getCacheValue('remove-container-1')).toBeUndefined();
+    });
+  });
+
+  describe('onContainerUpdated()', () => {
+    it('should do nothing if for some reason the container updated was not in the cache', () => {
+      ContextualIdentitiesEvents.onContainerUpdated({
+        contextualIdentity: {
+          ...defaultContextualIdentity,
+          cookieStoreId: 'non-existent-0',
+        },
+      });
+      expect(TestStore.getCacheValue('non-existent-0')).toBeUndefined();
+    });
+
+    it('should update the container name accordingly', () => {
+      TestStore.addCache({ key: 'container-01', value: 'oldValue' });
+      ContextualIdentitiesEvents.onContainerUpdated({
+        contextualIdentity: {
+          ...defaultContextualIdentity,
+          cookieStoreId: 'container-01',
+          name: 'newValue',
+        },
+      });
+      expect(TestStore.getCacheValue('container-01')).toEqual('newValue');
+    });
+  });
+});

--- a/__tests__/services/ContextualIdentitiesEvents.spec.ts
+++ b/__tests__/services/ContextualIdentitiesEvents.spec.ts
@@ -24,7 +24,7 @@ import * as Lib from '../../src/services/Libs';
 import StoreUser from '../../src/services/StoreUser';
 
 jest.requireActual('../../src/services/Libs');
-const spyLib: { [s: string]: jest.SpyInstance } = global.generateSpies(Lib);
+const spyLib: JestSpyObject = global.generateSpies(Lib);
 
 const store: Store<State, ReduxAction> = createStore(initialState);
 StoreUser.init(store);

--- a/__tests__/services/CookieEvents.spec.ts
+++ b/__tests__/services/CookieEvents.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2020 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { when } from 'jest-when';
+
+import CookieEvents from '../../src/services/CookieEvents';
+import * as Lib from '../../src/services/Libs';
+import TabEvents from '../../src/services/TabEvents';
+
+jest.requireActual('../../src/services/Libs');
+const spyLib: { [s: string]: jest.SpyInstance } = global.generateSpies(Lib);
+
+const defaultCookie: browser.cookies.Cookie = {
+  domain: 'domain.com',
+  hostOnly: false,
+  httpOnly: false,
+  name: 'CookieName',
+  path: '/',
+  sameSite: 'no_restriction',
+  secure: false,
+  session: true,
+  storeId: 'firefox-default',
+  value: 'CookieValue',
+};
+
+const defaultTab: browser.tabs.Tab = {
+  active: true,
+  cookieStoreId: 'firefox-container-00',
+  hidden: false,
+  highlighted: false,
+  incognito: false,
+  id: 1,
+  index: 0,
+  isArticle: false,
+  isInReaderMode: false,
+  lastAccessed: 12345678,
+  pinned: false,
+  selected: true,
+  url: 'https://domain.com',
+  windowId: 1,
+};
+
+describe('CookieEvents', () => {
+  when(global.browser.tabs.query)
+    .calledWith({ active: true, windowType: 'normal' })
+    .mockResolvedValue([
+      defaultTab,
+      { ...defaultTab, url: 'https://example.com' },
+    ] as never);
+
+  describe('onCookieChanged()', () => {
+    const spyTabUpdate = jest.spyOn(TabEvents, 'onTabUpdate');
+
+    it('should do nothing if cookie is not part of any active tabs', async () => {
+      await CookieEvents.onCookieChanged({
+        removed: false,
+        cookie: { ...defaultCookie, domain: '1.1.1.1' },
+        cause: 'overwrite',
+      });
+      expect(spyTabUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should force update that active tab if the domain matches', async () => {
+      await CookieEvents.onCookieChanged({
+        removed: false,
+        cookie: defaultCookie,
+        cause: 'overwrite',
+      });
+      expect(spyTabUpdate).toHaveBeenCalledTimes(1);
+      expect(spyTabUpdate.mock.calls[0][1].cookieChanged).toHaveProperty(
+        'cookie.value',
+        '***',
+      );
+    });
+
+    it('should not force tab update if tab url is undefined', async () => {
+      when(global.browser.tabs.query)
+        .calledWith({ active: true, windowType: 'normal' })
+        .mockResolvedValue([{ ...defaultTab, url: undefined }] as never);
+      await CookieEvents.onCookieChanged({
+        removed: false,
+        cookie: defaultCookie,
+        cause: 'overwrite',
+      });
+      expect(spyLib.getHostname).not.toHaveBeenCalled();
+    });
+
+    it('should not force tab update if tab id is undefined', async () => {
+      when(global.browser.tabs.query)
+        .calledWith({ active: true, windowType: 'normal' })
+        .mockResolvedValue([{ ...defaultTab, id: undefined }] as never);
+      await CookieEvents.onCookieChanged({
+        removed: false,
+        cookie: defaultCookie,
+        cause: 'overwrite',
+      });
+      expect(spyLib.getHostname).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/services/CookieEvents.spec.ts
+++ b/__tests__/services/CookieEvents.spec.ts
@@ -18,7 +18,7 @@ import * as Lib from '../../src/services/Libs';
 import TabEvents from '../../src/services/TabEvents';
 
 jest.requireActual('../../src/services/Libs');
-const spyLib: { [s: string]: jest.SpyInstance } = global.generateSpies(Lib);
+const spyLib: JestSpyObject = global.generateSpies(Lib);
 
 const defaultCookie: browser.cookies.Cookie = {
   domain: 'domain.com',

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -17,6 +17,7 @@ import {
   cadLog,
   convertVersionToNumber,
   createPartialTabInfo,
+  eventListenerActions,
   extractMainDomain,
   getAllCookiesForDomain,
   getContainerExpressionDefault,
@@ -298,6 +299,78 @@ describe('Library Functions', () => {
         url: 'https://test.cad',
         windowId: 1,
       });
+    });
+  });
+
+  describe('eventListenerActions()', () => {
+    it('should do nothing if an event was not passed in', () => {
+      expect(() => {
+        eventListenerActions(
+          undefined as any,
+          Function,
+          EventListenerAction.ADD,
+        );
+      }).not.toThrowError();
+      // Unexpected error would be TypeError: "cannot read property 'hasListener' of undefined"
+    });
+
+    it('should do nothing if an "event" passed in is not an Event Listener', () => {
+      expect(() => {
+        eventListenerActions({} as any, Function, EventListenerAction.REMOVE);
+      }).not.toThrowError();
+    });
+
+    it('should add the event listener', () => {
+      eventListenerActions(
+        browser.cookies.onChanged,
+        Function,
+        EventListenerAction.ADD,
+      );
+      expect(
+        global.browser.cookies.onChanged.addListener,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not add the event listener again if it already exists', () => {
+      when(global.browser.cookies.onChanged.hasListener)
+        .calledWith(expect.any(Function))
+        .mockReturnValue(true);
+      eventListenerActions(
+        browser.cookies.onChanged,
+        Function,
+        EventListenerAction.ADD,
+      );
+      expect(
+        global.browser.cookies.onChanged.addListener,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should remove the listener', () => {
+      when(global.browser.cookies.onChanged.hasListener)
+        .calledWith(expect.any(Function))
+        .mockReturnValue(true);
+      eventListenerActions(
+        browser.cookies.onChanged,
+        Function,
+        EventListenerAction.REMOVE,
+      );
+      expect(
+        global.browser.cookies.onChanged.removeListener,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not remove a non-existent listener', () => {
+      when(global.browser.cookies.onChanged.hasListener)
+        .calledWith(expect.any(Function))
+        .mockReturnValue(false);
+      eventListenerActions(
+        browser.cookies.onChanged,
+        Function,
+        EventListenerAction.REMOVE,
+      );
+      expect(
+        global.browser.cookies.onChanged.removeListener,
+      ).not.toHaveBeenCalled();
     });
   });
 
@@ -622,7 +695,7 @@ describe('Library Functions', () => {
             settings: {
               ...initialState.settings,
               contextualIdentities: {
-                name: 'contextualIdentities',
+                name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
                 value: true,
               },
             },
@@ -652,7 +725,7 @@ describe('Library Functions', () => {
             settings: {
               ...initialState.settings,
               contextualIdentities: {
-                name: 'contextualIdentities',
+                name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
                 value: true,
               },
             },
@@ -708,7 +781,9 @@ describe('Library Functions', () => {
 
   describe('getSetting()', () => {
     it('should return value of false for activeMode in default settings', () => {
-      expect(getSetting(initialState, 'activeMode')).toEqual(false);
+      expect(getSetting(initialState, `${SettingID.ACTIVE_MODE}`)).toEqual(
+        false,
+      );
     });
   });
 
@@ -721,7 +796,7 @@ describe('Library Functions', () => {
       settings: {
         contextualIdentities: {
           id: 7,
-          name: 'contextualIdentities',
+          name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
           value: false,
         },
       },
@@ -734,7 +809,7 @@ describe('Library Functions', () => {
       settings: {
         contextualIdentities: {
           id: 7,
-          name: 'contextualIdentities',
+          name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
           value: false,
         },
       },
@@ -747,7 +822,7 @@ describe('Library Functions', () => {
       settings: {
         contextualIdentities: {
           id: 7,
-          name: 'contextualIdentities',
+          name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
           value: true,
         },
       },

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -694,7 +694,7 @@ describe('Library Functions', () => {
             ...initialState,
             settings: {
               ...initialState.settings,
-              contextualIdentities: {
+              [`${SettingID.CONTEXTUAL_IDENTITIES}`]: {
                 name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
                 value: true,
               },
@@ -724,7 +724,7 @@ describe('Library Functions', () => {
             ...initialState,
             settings: {
               ...initialState.settings,
-              contextualIdentities: {
+              [`${SettingID.CONTEXTUAL_IDENTITIES}`]: {
                 name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
                 value: true,
               },
@@ -794,7 +794,7 @@ describe('Library Functions', () => {
         browserDetect: browserName.Chrome,
       },
       settings: {
-        contextualIdentities: {
+        [`${SettingID.CONTEXTUAL_IDENTITIES}`]: {
           id: 7,
           name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
           value: false,
@@ -807,7 +807,7 @@ describe('Library Functions', () => {
         browserDetect: browserName.Firefox,
       },
       settings: {
-        contextualIdentities: {
+        [`${SettingID.CONTEXTUAL_IDENTITIES}`]: {
           id: 7,
           name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
           value: false,
@@ -820,7 +820,7 @@ describe('Library Functions', () => {
         browserDetect: browserName.Firefox,
       },
       settings: {
-        contextualIdentities: {
+        [`${SettingID.CONTEXTUAL_IDENTITIES}`]: {
           id: 7,
           name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
           value: true,

--- a/__tests__/services/SettingService.spec.ts
+++ b/__tests__/services/SettingService.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2020 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { when } from 'jest-when';
+import { Store } from 'redux';
+import { initialState } from '../../src/redux/State';
+// tslint:disable-next-line: import-name
+import createStore from '../../src/redux/Store';
+import * as BrowserActionService from '../../src/services/BrowserActionService';
+import ContextualIdentitiesEvents from '../../src/services/ContextualIdentitiesEvents';
+import SettingService from '../../src/services/SettingService';
+import StoreUser from '../../src/services/StoreUser';
+import { ReduxAction } from '../../src/typings/ReduxConstants';
+import { resetSettings, updateSetting } from '../../src/redux/Actions';
+import ContextMenuEvents from '../../src/services/ContextMenuEvents';
+
+const spyBrowserActions: JestSpyObject = global.generateSpies(
+  BrowserActionService,
+);
+
+jest.requireActual('../../src/services/ContextMenuEvents');
+class TestContextMenus extends ContextMenuEvents {
+  public static isInit(): boolean {
+    return ContextMenuEvents.isInitialized;
+  }
+}
+
+jest.requireActual('../../src/services/ContextualIdentitiesEvents');
+class TestContextualIdentities extends ContextualIdentitiesEvents {
+  public static isInit(): boolean {
+    return ContextualIdentitiesEvents.isInitialized;
+  }
+}
+
+jest.requireActual('../../src/services/StoreUser');
+const store: Store<State, ReduxAction> = createStore(initialState);
+StoreUser.init(store);
+
+class TestStore extends StoreUser {
+  public static changeSetting(
+    name: SettingID,
+    value: string | boolean | number,
+  ) {
+    StoreUser.store.dispatch(updateSetting({ name, value }));
+  }
+
+  public static resetSetting() {
+    StoreUser.store.dispatch(resetSettings());
+  }
+}
+
+class TestSettingService extends SettingService {
+  public static getIsInitialized() {
+    return SettingService.isInitialized;
+  }
+
+  public static getTestCurrent() {
+    return SettingService.current;
+  }
+
+  public static setIsInitialized(value: boolean) {
+    SettingService.isInitialized = value;
+  }
+}
+
+const defaultTab: browser.tabs.Tab = {
+  active: true,
+  cookieStoreId: 'firefox-container-5',
+  hidden: false,
+  highlighted: false,
+  incognito: false,
+  id: 1,
+  index: 0,
+  isArticle: false,
+  isInReaderMode: false,
+  lastAccessed: 12345678,
+  pinned: false,
+  selected: true,
+  url: 'https://domain.com',
+  windowId: 1,
+};
+
+describe('SettingService', () => {
+  beforeEach(() => {
+    when(global.browser.runtime.getManifest)
+      .calledWith()
+      .mockReturnValue({ version: '0.12.34' });
+    when(global.browser.contextualIdentities.query)
+      .calledWith({})
+      .mockResolvedValue([] as never);
+    when(global.browser.tabs.query)
+      .calledWith({ windowType: 'normal' })
+      .mockResolvedValue([] as never);
+    when(global.browser.contextMenus.update)
+      .calledWith(expect.anything())
+      .mockResolvedValue(null as never);
+  });
+
+  afterEach(() => {
+    TestStore.resetSetting();
+  });
+
+  describe('init()', () => {
+    it('should fetch settings from store state', () => {
+      SettingService.init();
+      expect(TestSettingService.getIsInitialized()).toEqual(true);
+      expect(TestSettingService.getTestCurrent()).toEqual(
+        initialState.settings,
+      );
+    });
+  });
+  describe('onSettingsChange()', () => {
+    when(global.browser.tabs.query)
+      .calledWith({ active: true, windowType: 'normal' })
+      .mockResolvedValue([
+        defaultTab,
+        { ...defaultTab, url: 'https://example.com' },
+      ] as never);
+    it('should init if not yet initialized', async () => {
+      TestSettingService.setIsInitialized(false);
+      expect(TestSettingService.getIsInitialized()).toEqual(false);
+      await SettingService.onSettingsChange();
+      expect(TestSettingService.getIsInitialized()).toEqual(true);
+    });
+    it('should initialize ContextualIdentities if recently enabled', async () => {
+      expect(TestContextualIdentities.isInit()).toEqual(false);
+      TestStore.changeSetting(SettingID.CONTEXTUAL_IDENTITIES, true);
+      await SettingService.onSettingsChange();
+      expect(TestContextualIdentities.isInit()).toEqual(true);
+    });
+    it('should de-init ContextualIdentities if recently disabled', async () => {
+      expect(TestContextualIdentities.isInit()).toEqual(true);
+      TestStore.changeSetting(SettingID.CONTEXTUAL_IDENTITIES, false);
+      await SettingService.onSettingsChange();
+      expect(TestContextualIdentities.isInit()).toEqual(false);
+    });
+    it('should not clean localstorage if migrating from old setting', async () => {
+      TestStore.changeSetting(SettingID.CLEANUP_LOCALSTORAGE_OLD, true);
+      await SettingService.onSettingsChange();
+      TestStore.changeSetting(SettingID.CLEANUP_LOCALSTORAGE, true);
+      await SettingService.onSettingsChange();
+      expect(global.browser.browsingData.remove).not.toHaveBeenCalled();
+    });
+    it('should clean that site data if it was recently enabled', async () => {
+      TestStore.changeSetting(SettingID.CLEANUP_CACHE, true);
+      await SettingService.onSettingsChange();
+      expect(global.browser.browsingData.remove).toHaveBeenCalledTimes(1);
+    });
+    it('should enable global icon if active mode was recently enabled', async () => {
+      TestStore.changeSetting(SettingID.ACTIVE_MODE, true);
+      await SettingService.onSettingsChange();
+      expect(spyBrowserActions.setGlobalIcon).toHaveBeenCalledWith(true);
+    });
+    it('should make global icon greyscale and clear alarms if active mode was recently disabled', async () => {
+      TestStore.changeSetting(SettingID.ACTIVE_MODE, false);
+      await SettingService.onSettingsChange();
+      expect(global.browser.alarms.clear).toHaveBeenCalledTimes(1);
+      expect(spyBrowserActions.setGlobalIcon).toHaveBeenCalledWith(false);
+    });
+    it('should clear contextMenus if recently disabled', async () => {
+      TestStore.changeSetting(SettingID.CONTEXT_MENUS, false);
+      await SettingService.onSettingsChange();
+      expect(TestContextMenus.isInit()).toEqual(false);
+    });
+    it('should init contextMenu items if recently enabled', async () => {
+      TestStore.changeSetting(SettingID.CONTEXT_MENUS, true);
+      await SettingService.onSettingsChange();
+      expect(TestContextMenus.isInit()).toEqual(true);
+    });
+  });
+});

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -176,7 +176,7 @@ describe('TabEvents', () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
-      TestStore.changeSetting('cacheCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEANUP_CACHE}`, true);
       await TabEvents.getAllCookieActions({
         ...sampleTab,
         url: 'http://cookie.net',
@@ -188,7 +188,7 @@ describe('TabEvents', () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
-      TestStore.changeSetting('indexedDBCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEANUP_INDEXEDDB}`, true);
       await TabEvents.getAllCookieActions({
         ...sampleTab,
         url: 'http://cookie.net',
@@ -200,7 +200,7 @@ describe('TabEvents', () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
-      TestStore.changeSetting('localStorageCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEANUP_LOCALSTORAGE}`, true);
       await TabEvents.getAllCookieActions({
         ...sampleTab,
         url: 'http://cookie.net',
@@ -212,7 +212,7 @@ describe('TabEvents', () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
-      TestStore.changeSetting('pluginDataCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEANUP_PLUGIN_DATA}`, true);
       await TabEvents.getAllCookieActions({
         ...sampleTab,
         url: 'http://cookie.net',
@@ -224,7 +224,7 @@ describe('TabEvents', () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
-      TestStore.changeSetting('serviceWorkersCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEANUP_SERVICE_WORKERS}`, true);
       await TabEvents.getAllCookieActions({
         ...sampleTab,
         url: 'http://cookie.net',
@@ -280,20 +280,20 @@ describe('TabEvents', () => {
 
   describe('onTabDiscarded', () => {
     it('should do nothing if clean discarded tabs setting is not enabled', () => {
-      TestStore.changeSetting('discardedCleanup', false);
+      TestStore.changeSetting(`${SettingID.CLEAN_DISCARDED}`, false);
       TabEvents.onTabDiscarded(0, sampleChangeInfo, sampleTab);
       expect(spyLib.createPartialTabInfo).not.toHaveBeenCalled();
       expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
     });
 
     it('should do nothing if the tab that was updated is not discarded, even if discardedCleanup was true', () => {
-      TestStore.changeSetting('discardedCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEAN_DISCARDED}`, true);
       TabEvents.onTabDiscarded(0, sampleChangeInfo, sampleTab);
       expect(spyTabEvents.cleanFromTabEvents).not.toHaveBeenCalled();
     });
 
     it('should trigger cleaning if clean discarded tabs is enabled and changeInfo was discarded', () => {
-      TestStore.changeSetting('discardedCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEAN_DISCARDED}`, true);
       TabEvents.onTabDiscarded(
         0,
         { ...sampleChangeInfo, discarded: true },
@@ -303,8 +303,8 @@ describe('TabEvents', () => {
     });
 
     it('should sanitize favIconUrl if debug was enabled', () => {
-      TestStore.changeSetting('discardedCleanup', true);
-      TestStore.changeSetting('debugMode', true);
+      TestStore.changeSetting(`${SettingID.CLEAN_DISCARDED}`, true);
+      TestStore.changeSetting(`${SettingID.DEBUG_MODE}`, true);
       TabEvents.onTabDiscarded(0, { ...sampleChangeInfo }, sampleTab);
       expect(spyLib.cadLog.mock.calls[0][0].x.changeInfo.favIconUrl).toBe(
         '***',
@@ -340,7 +340,7 @@ describe('TabEvents', () => {
     });
 
     it('should sanitize favIconUrl if status=complete and debug is true', () => {
-      TestStore.changeSetting('debugMode', true);
+      TestStore.changeSetting(`${SettingID.DEBUG_MODE}`, true);
       TabEvents.onTabUpdate(0, sampleChangeInfo, {
         ...sampleTab,
         status: 'complete',
@@ -351,7 +351,7 @@ describe('TabEvents', () => {
     });
 
     it('should not queue getAllCookieActions if one is pending already', () => {
-      TestStore.changeSetting('debugMode', true);
+      TestStore.changeSetting(`${SettingID.DEBUG_MODE}`, true);
       expect(TestTabEvents.getOnTabUpdateDelay()).toBe(false);
       TabEvents.onTabUpdate(0, sampleChangeInfo, {
         ...sampleTab,
@@ -389,7 +389,7 @@ describe('TabEvents', () => {
     });
 
     it('should truncate favIconUrl if debug=true', () => {
-      TestStore.changeSetting('debugMode', true);
+      TestStore.changeSetting(`${SettingID.DEBUG_MODE}`, true);
       expect(Object.keys(TestTabEvents.getTabToDomain()).length).toBe(1);
       TabEvents.onDomainChange(0, sampleChangeInfo, {
         ...sampleTab,
@@ -421,7 +421,7 @@ describe('TabEvents', () => {
     });
 
     it('should trigger clean if mainDomain was changed and domainChangeCleanup is enabled', () => {
-      TestStore.changeSetting('domainChangeCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEAN_DOMAIN_CHANGE}`, true);
       // reuse previous tabId to change domain
       expect(TestTabEvents.getTabToDomain()[0]).toBe('domain.cad');
       TabEvents.onDomainChange(0, sampleChangeInfo, {
@@ -433,7 +433,7 @@ describe('TabEvents', () => {
     });
 
     it('should trigger clean if mainDomain was changed to a home/blank/new tab and domainChangeCleanup is enabled', () => {
-      TestStore.changeSetting('domainChangeCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEAN_DOMAIN_CHANGE}`, true);
       // reuse previous tabId to change domain to blank
       expect(TestTabEvents.getTabToDomain()[0]).toBe('example.com');
       TabEvents.onDomainChange(0, sampleChangeInfo, {
@@ -446,7 +446,7 @@ describe('TabEvents', () => {
     });
 
     it('should not trigger cleaning if previous domain was a new/blank/home tab with domainChangeCleanup enabled', () => {
-      TestStore.changeSetting('domainChangeCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEAN_DOMAIN_CHANGE}`, true);
       // reuse previous tabId of blank tab to new domain.
       expect(TestTabEvents.getTabToDomain()[0]).toBe('');
       TabEvents.onDomainChange(0, sampleChangeInfo, {
@@ -458,7 +458,7 @@ describe('TabEvents', () => {
     });
 
     it('should not trigger if next domain is an empty string (highly unlikely scenario)', () => {
-      TestStore.changeSetting('domainChangeCleanup', true);
+      TestStore.changeSetting(`${SettingID.CLEAN_DOMAIN_CHANGE}`, true);
       // reuse previous tabId to go from domain to empty string...which usually doesn't happen
       expect(TestTabEvents.getTabToDomain()[0]).toBe('example.com');
       TabEvents.onDomainChange(0, sampleChangeInfo, {
@@ -498,8 +498,8 @@ describe('TabEvents', () => {
       when(global.browser.alarms.get)
         .calledWith('activeModeAlarm')
         .mockResolvedValue(undefined as never);
-      TestStore.changeSetting('activeMode', true);
-      TestStore.changeSetting('delayBeforeClean', 1);
+      TestStore.changeSetting(`${SettingID.ACTIVE_MODE}`, true);
+      TestStore.changeSetting(`${SettingID.CLEAN_DELAY}`, 1);
       await TabEvents.cleanFromTabEvents();
       expect(spyAlarmEvents.createActiveModeAlarm).toHaveBeenCalledTimes(1);
     });
@@ -508,7 +508,7 @@ describe('TabEvents', () => {
       when(global.browser.alarms.get)
         .calledWith('activeModeAlarm')
         .mockResolvedValue({ name: 'activeModeAlarm' } as never);
-      TestStore.changeSetting('activeMode', true);
+      TestStore.changeSetting(`${SettingID.ACTIVE_MODE}`, true);
       await TabEvents.cleanFromTabEvents();
       expect(spyAlarmEvents.createActiveModeAlarm).not.toHaveBeenCalled();
     });

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -26,18 +26,14 @@ import TabEvents from '../../src/services/TabEvents';
 import StoreUser from '../../src/services/StoreUser';
 
 jest.requireActual('../../src/services/AlarmEvents');
-const spyAlarmEvents: { [s: string]: jest.SpyInstance } = global.generateSpies(
-  AlarmEvents,
+const spyAlarmEvents: JestSpyObject = global.generateSpies(AlarmEvents);
+const spyBrowserActions: JestSpyObject = global.generateSpies(
+  BrowserActionService,
 );
-const spyBrowserActions: {
-  [s: string]: jest.SpyInstance;
-} = global.generateSpies(BrowserActionService);
 jest.requireActual('../../src/services/Libs');
-const spyLib: { [s: string]: jest.SpyInstance } = global.generateSpies(Lib);
+const spyLib: JestSpyObject = global.generateSpies(Lib);
 jest.requireActual('../../src/services/TabEvents');
-const spyTabEvents: { [s: string]: jest.SpyInstance } = global.generateSpies(
-  TabEvents,
-);
+const spyTabEvents: JestSpyObject = global.generateSpies(TabEvents);
 
 jest.requireActual('../../src/services/StoreUser');
 

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -264,7 +264,7 @@ describe('TabEvents', () => {
         .calledWith({ domain: '' })
         .mockResolvedValueOnce([] as never)
         .mockRejectedValue(new Error('firstPartyDomain') as never);
-      TestStore.changeSetting('cacheCleanup', true);
+      TestStore.changeSetting(SettingID.CLEANUP_CACHE, true);
       TestStore.addCache({ key: 'browserDetect', value: browserName.Firefox });
 
       await TabEvents.getAllCookieActions({

--- a/src/background.ts
+++ b/src/background.ts
@@ -111,11 +111,11 @@ const onSettingsChange = async () => {
     }
   }
 
-  if (previousSettings.activeMode.value && !currentSettings.activeMode.value) {
-    await browser.alarms.clear('activeModeAlarm');
-  }
-
+  // Active Mode (Automatic Cleaning) changes
   if (previousSettings.activeMode.value !== currentSettings.activeMode.value) {
+    if (!currentSettings.activeMode.value) {
+      await browser.alarms.clear('activeModeAlarm');
+    }
     await setGlobalIcon(currentSettings.activeMode.value as boolean);
     ContextMenuEvents.updateMenuItemCheckbox(
       ContextMenuEvents.MenuID.ACTIVE_MODE,
@@ -136,13 +136,29 @@ const onSettingsChange = async () => {
 
   // Deprecated Settings adjustments - only for localstorageCleanup<->localStorageCleanup
   if (
+    previousSettings.localStorageCleanup &&
+    currentSettings.localStorageCleanup &&
     previousSettings.localStorageCleanup.value !==
-    currentSettings.localStorageCleanup.value
+      currentSettings.localStorageCleanup.value
   ) {
     store.dispatch({
       payload: {
         name: 'localstorageCleanup',
         value: currentSettings.localStorageCleanup.value as boolean,
+      },
+      type: ReduxConstants.UPDATE_SETTING,
+    });
+  }
+  if (
+    previousSettings.localstorageCleanup &&
+    currentSettings.localstorageCleanup &&
+    previousSettings.localstorageCleanup.value !==
+      currentSettings.localstorageCleanup.value
+  ) {
+    store.dispatch({
+      payload: {
+        name: 'localStorageCleanup',
+        value: currentSettings.localstorageCleanup.value as boolean,
       },
       type: ReduxConstants.UPDATE_SETTING,
     });

--- a/src/background.ts
+++ b/src/background.ts
@@ -77,10 +77,10 @@ const onSettingsChange = async () => {
   currentSettings = store.getState().settings;
   // Container Mode changes
   if (
-    previousSettings.contextualIdentities.value !==
-    currentSettings.contextualIdentities.value
+    previousSettings[`${SettingID.CONTEXTUAL_IDENTITIES}`].value !==
+    currentSettings[`${SettingID.CONTEXTUAL_IDENTITIES}`].value
   ) {
-    if (currentSettings.contextualIdentities.value) {
+    if (currentSettings[`${SettingID.CONTEXTUAL_IDENTITIES}`].value) {
       ContextualIdentitiesEvents.init();
       store.dispatch<any>(cacheCookieStoreIdNames());
     } else {
@@ -106,28 +106,34 @@ const onSettingsChange = async () => {
       }
       await browsingDataCleanup(
         siteData,
-        currentSettings.debugMode.value as boolean,
+        currentSettings[`${SettingID.DEBUG_MODE}`].value as boolean,
       );
     }
   }
 
   // Active Mode (Automatic Cleaning) changes
-  if (previousSettings.activeMode.value !== currentSettings.activeMode.value) {
-    if (!currentSettings.activeMode.value) {
+  if (
+    previousSettings[`${SettingID.ACTIVE_MODE}`].value !==
+    currentSettings[`${SettingID.ACTIVE_MODE}`].value
+  ) {
+    if (!currentSettings[`${SettingID.ACTIVE_MODE}`].value) {
       await browser.alarms.clear('activeModeAlarm');
     }
-    await setGlobalIcon(currentSettings.activeMode.value as boolean);
+    await setGlobalIcon(
+      currentSettings[`${SettingID.ACTIVE_MODE}`].value as boolean,
+    );
     ContextMenuEvents.updateMenuItemCheckbox(
       ContextMenuEvents.MenuID.ACTIVE_MODE,
-      currentSettings.activeMode.value as boolean,
+      currentSettings[`${SettingID.ACTIVE_MODE}`].value as boolean,
     );
   }
 
   // Context Menu Changes
   if (
-    previousSettings.contextMenus.value !== currentSettings.contextMenus.value
+    previousSettings[`${SettingID.CONTEXT_MENUS}`].value !==
+    currentSettings[`${SettingID.CONTEXT_MENUS}`].value
   ) {
-    if (currentSettings.contextMenus.value) {
+    if (currentSettings[`${SettingID.CONTEXT_MENUS}`].value) {
       ContextMenuEvents.menuInit();
     } else {
       await ContextMenuEvents.menuClear();
@@ -136,29 +142,31 @@ const onSettingsChange = async () => {
 
   // Deprecated Settings adjustments - only for localstorageCleanup<->localStorageCleanup
   if (
-    previousSettings.localStorageCleanup &&
-    currentSettings.localStorageCleanup &&
-    previousSettings.localStorageCleanup.value !==
-      currentSettings.localStorageCleanup.value
+    previousSettings[`${SettingID.CLEANUP_LOCALSTORAGE}`] &&
+    currentSettings[`${SettingID.CLEANUP_LOCALSTORAGE}`] &&
+    previousSettings[`${SettingID.CLEANUP_LOCALSTORAGE}`].value !==
+      currentSettings[`${SettingID.CLEANUP_LOCALSTORAGE}`].value
   ) {
     store.dispatch({
       payload: {
-        name: 'localstorageCleanup',
-        value: currentSettings.localStorageCleanup.value as boolean,
+        name: `${SettingID.CLEANUP_LOCALSTORAGE_OLD}`,
+        value: currentSettings[`${SettingID.CLEANUP_LOCALSTORAGE}`]
+          .value as boolean,
       },
       type: ReduxConstants.UPDATE_SETTING,
     });
   }
   if (
-    previousSettings.localstorageCleanup &&
-    currentSettings.localstorageCleanup &&
-    previousSettings.localstorageCleanup.value !==
-      currentSettings.localstorageCleanup.value
+    previousSettings[`${SettingID.CLEANUP_LOCALSTORAGE_OLD}`] &&
+    currentSettings[`${SettingID.CLEANUP_LOCALSTORAGE_OLD}`] &&
+    previousSettings[`${SettingID.CLEANUP_LOCALSTORAGE_OLD}`].value !==
+      currentSettings[`${SettingID.CLEANUP_LOCALSTORAGE_OLD}`].value
   ) {
     store.dispatch({
       payload: {
-        name: 'localStorageCleanup',
-        value: currentSettings.localstorageCleanup.value as boolean,
+        name: `${SettingID.CLEANUP_LOCALSTORAGE}`,
+        value: currentSettings[`${SettingID.CLEANUP_LOCALSTORAGE_OLD}`]
+          .value as boolean,
       },
       type: ReduxConstants.UPDATE_SETTING,
     });
@@ -231,7 +239,9 @@ const onStartUp = async () => {
 
   store.dispatch<any>(validateSettings());
 
-  await setGlobalIcon(getSetting(store.getState(), 'activeMode') as boolean);
+  await setGlobalIcon(
+    getSetting(store.getState(), `${SettingID.ACTIVE_MODE}`) as boolean,
+  );
 
   await checkIfProtected(store.getState());
 
@@ -321,13 +331,13 @@ onStartUp().then(() => {
       msg: `background.onStartUp has been executed`,
       type: 'info',
     },
-    getSetting(store.getState(), 'debugMode') as boolean,
+    getSetting(store.getState(), `${SettingID.DEBUG_MODE}`) as boolean,
   );
 });
 browser.runtime.onStartup.addListener(async () => {
   await awaitStore();
-  if (getSetting(store.getState(), 'activeMode') === true) {
-    if (getSetting(store.getState(), 'enableGreyListCleanup') === true) {
+  if (getSetting(store.getState(), `${SettingID.ACTIVE_MODE}`) === true) {
+    if (getSetting(store.getState(), `${SettingID.ENABLE_GREYLIST}`) === true) {
       let isFFSessionRestore = false;
       const startupTabs = await browser.tabs.query({ windowType: 'normal' });
       startupTabs.forEach((tab) => {
@@ -342,7 +352,7 @@ browser.runtime.onStartup.addListener(async () => {
               'Found a tab with [ about:sessionrestore ] in Firefox. Skipping Grey startup cleanup this time.',
             type: 'info',
           },
-          getSetting(store.getState(), 'debugMode') === true,
+          getSetting(store.getState(), `${SettingID.DEBUG_MODE}`) === true,
         );
       }
     } else {
@@ -352,7 +362,7 @@ browser.runtime.onStartup.addListener(async () => {
             'GreyList Cleanup setting is disabled.  Not cleaning cookies on startup.',
           type: 'info',
         },
-        getSetting(store.getState(), 'debugMode') === true,
+        getSetting(store.getState(), `${SettingID.DEBUG_MODE}`) === true,
       );
     }
   }
@@ -373,7 +383,7 @@ browser.runtime.onInstalled.addListener(async (details) => {
         if (store.getState().settings.localstorageCleanup) {
           store.dispatch({
             payload: {
-              name: 'localStorageCleanup',
+              name: `${SettingID.CLEANUP_LOCALSTORAGE}`,
               value: store.getState().settings.localstorageCleanup
                 .value as boolean,
             },
@@ -405,7 +415,9 @@ browser.runtime.onInstalled.addListener(async (details) => {
               Object.keys(store.getState().lists),
             );
             containers.add('default');
-            if (getSetting(store.getState(), 'contextualIdentities')) {
+            if (
+              getSetting(store.getState(), `${SettingID.CONTEXTUAL_IDENTITIES}`)
+            ) {
               const contextualIdentitiesObjects = await browser.contextualIdentities.query(
                 {},
               );
@@ -432,7 +444,7 @@ browser.runtime.onInstalled.addListener(async (details) => {
           type: ReduxConstants.RESET_COOKIE_DELETED_COUNTER,
         });
       }
-      if (getSetting(store.getState(), 'enableNewVersionPopup')) {
+      if (getSetting(store.getState(), `${SettingID.ENABLE_NEW_POPUP}`)) {
         await browser.runtime.openOptionsPage();
       }
       break;
@@ -448,19 +460,19 @@ const awaitStore = async () => {
 };
 
 const greyCleanup = () => {
-  if (getSetting(store.getState(), 'activeMode')) {
+  if (getSetting(store.getState(), `${SettingID.ACTIVE_MODE}`)) {
     cadLog(
       {
         msg: `background.greyCleanup:  dispatching browser restart greyCleanup.`,
       },
-      getSetting(store.getState(), 'debugMode') as boolean,
+      getSetting(store.getState(), `${SettingID.DEBUG_MODE}`) as boolean,
     );
     store.dispatch<any>(
       cookieCleanup({
         greyCleanup: true,
         ignoreOpenTabs: getSetting(
           store.getState(),
-          'cleanCookiesFromOpenTabsOnStartup',
+          `${SettingID.CLEAN_OPEN_TABS_STARTUP}`,
         ),
       }),
     );

--- a/src/background.ts
+++ b/src/background.ts
@@ -99,8 +99,8 @@ const onSettingsChange = async () => {
       // Only if migrating from 3.4.0 to 3.5.1+
       if (
         siteData === SiteDataType.LOCALSTORAGE &&
-        previousSettings['localstorageCleanup'] !== undefined &&
-        previousSettings['localstorageCleanup'].value
+        previousSettings[SettingID.CLEANUP_LOCALSTORAGE_OLD] !== undefined &&
+        previousSettings[SettingID.CLEANUP_LOCALSTORAGE_OLD].value
       ) {
         continue;
       }
@@ -380,12 +380,15 @@ browser.runtime.onInstalled.addListener(async (details) => {
       store.dispatch<any>(validateSettings());
       if (convertVersionToNumber(details.previousVersion) < 350) {
         // Migrate State Setting Name localstorageCleanup to localStorageCleanup
-        if (store.getState().settings.localstorageCleanup) {
+        if (
+          store.getState().settings[`${SettingID.CLEANUP_LOCALSTORAGE_OLD}`]
+        ) {
           store.dispatch({
             payload: {
               name: `${SettingID.CLEANUP_LOCALSTORAGE}`,
-              value: store.getState().settings.localstorageCleanup
-                .value as boolean,
+              value: store.getState().settings[
+                `${SettingID.CLEANUP_LOCALSTORAGE_OLD}`
+              ].value as boolean,
             },
             type: ReduxConstants.UPDATE_SETTING,
           });

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -285,32 +285,32 @@ export const validateSettings: ActionCreator<ThunkAction<
 
   // Disable unusable setting in Chrome
   if (isChrome(cache)) {
-    disableSettingIfTrue(settings.contextualIdentities);
+    disableSettingIfTrue(settings[`${SettingID.CONTEXTUAL_IDENTITIES}`]);
   }
   // Disable unusable setting in Firefox Android
   if (isFirefoxAndroid(cache)) {
-    disableSettingIfTrue(settings.showNumOfCookiesInIcon);
-    disableSettingIfTrue(settings.localstorageCleanup);
-    disableSettingIfTrue(settings.localStorageCleanup);
-    disableSettingIfTrue(settings.contextualIdentities);
-    disableSettingIfTrue(settings.contextMenus);
+    disableSettingIfTrue(settings[`${SettingID.NUM_COOKIES_ICON}`]);
+    disableSettingIfTrue(settings[`${SettingID.CLEANUP_LOCALSTORAGE_OLD}`]);
+    disableSettingIfTrue(settings[`${SettingID.CLEANUP_LOCALSTORAGE}`]);
+    disableSettingIfTrue(settings[`${SettingID.CONTEXTUAL_IDENTITIES}`]);
+    disableSettingIfTrue(settings[`${SettingID.CONTEXT_MENUS}`]);
   }
 
   // Minimum 1 second autoclean delay.
-  if (settings.delayBeforeClean.value < 1) {
+  if (settings[`${SettingID.CLEAN_DELAY}`].value < 1) {
     dispatch({
       payload: {
-        ...settings.delayBeforeClean,
+        name: SettingID.CLEAN_DELAY,
         value: 1,
       },
       type: ReduxConstants.UPDATE_SETTING,
     });
   }
   // Maximum 2147483 seconds due to signed 32-bit Integer (ms x 1000)
-  if (settings.delayBeforeClean.value > 2147483) {
+  if (settings[`${SettingID.CLEAN_DELAY}`].value > 2147483) {
     dispatch({
       payload: {
-        ...settings.delayBeforeClean,
+        name: SettingID.CLEAN_DELAY,
         value: 2147483,
       },
       type: ReduxConstants.UPDATE_SETTING,
@@ -319,10 +319,10 @@ export const validateSettings: ActionCreator<ThunkAction<
 
   // If show cookie count in badge is disabled, force change icon color instead
   if (
-    !settings.showNumOfCookiesInIcon.value &&
-    settings.keepDefaultIcon.value
+    !settings[`${SettingID.NUM_COOKIES_ICON}`].value &&
+    settings[`${SettingID.KEEP_DEFAULT_ICON}`].value
   ) {
-    disableSettingIfTrue(settings.keepDefaultIcon);
+    disableSettingIfTrue(settings[`${SettingID.KEEP_DEFAULT_ICON}`]);
   }
 };
 
@@ -393,10 +393,7 @@ export const cookieCleanup: ActionCreator<ThunkAction<
       }
       if (domainsAll.size > 0) {
         await showNotification({
-          duration: getSetting(
-            getState(),
-            `${SettingID.NOTIFY_DURATION}`,
-          ) as number,
+          duration: getSetting(getState(), SettingID.NOTIFY_DURATION) as number,
           msg: browser.i18n.getMessage('activityLogSiteDataDomainsText', [
             browser.i18n.getMessage('siteDataText'),
             Array.from(domainsAll).join(', '),

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -352,19 +352,22 @@ export const cookieCleanup: ActionCreator<ThunkAction<
   } = cachedResults as ActivityLog;
 
   // Increment the count
-  if (recentlyCleaned !== 0 && getSetting(getState(), 'statLogging')) {
+  if (
+    recentlyCleaned !== 0 &&
+    getSetting(getState(), `${SettingID.STAT_LOGGING}`)
+  ) {
     dispatch(incrementCookieDeletedCounter(recentlyCleaned));
   }
 
   if (
     (recentlyCleaned !== 0 || siteDataCleaned) &&
-    getSetting(getState(), 'statLogging')
+    getSetting(getState(), `${SettingID.STAT_LOGGING}`)
   ) {
     dispatch(addActivity(cachedResults));
   }
 
   // Show notifications after cleanup
-  if (getSetting(getState(), 'showNotificationAfterCleanup')) {
+  if (getSetting(getState(), `${SettingID.NOTIFY_AUTO}`)) {
     if (setOfDeletedDomainCookies.length > 0) {
       // Cookie Notification
       const notifyMessage = browser.i18n.getMessage('notificationContent', [
@@ -372,7 +375,10 @@ export const cookieCleanup: ActionCreator<ThunkAction<
         setOfDeletedDomainCookies.join(', '),
       ]);
       showNotification({
-        duration: getSetting(getState(), 'notificationOnScreen') as number,
+        duration: getSetting(
+          getState(),
+          `${SettingID.NOTIFY_DURATION}`,
+        ) as number,
         msg: notifyMessage,
         title: browser.i18n.getMessage('notificationTitle'),
       });
@@ -387,7 +393,10 @@ export const cookieCleanup: ActionCreator<ThunkAction<
       }
       if (domainsAll.size > 0) {
         await showNotification({
-          duration: getSetting(getState(), 'notificationOnScreen') as number,
+          duration: getSetting(
+            getState(),
+            `${SettingID.NOTIFY_DURATION}`,
+          ) as number,
           msg: browser.i18n.getMessage('activityLogSiteDataDomainsText', [
             browser.i18n.getMessage('siteDataText'),
             Array.from(domainsAll).join(', '),

--- a/src/redux/State.ts
+++ b/src/redux/State.ts
@@ -18,115 +18,115 @@ export const initialState: State = {
   cookieDeletedCounterTotal: 0,
   cookieDeletedCounterSession: 0,
   settings: {
-    activeMode: {
-      name: 'activeMode',
+    [`${SettingID.ACTIVE_MODE}`]: {
+      name: `${SettingID.ACTIVE_MODE}`,
       value: false,
     },
-    cacheCleanup: {
-      name: 'cacheCleanup',
+    [`${SettingID.CLEANUP_CACHE}`]: {
+      name: `${SettingID.CLEANUP_CACHE}`,
       value: false,
     },
-    cleanCookiesFromOpenTabsOnStartup: {
-      name: 'cleanCookiesFromOpenTabsOnStartup',
+    [`${SettingID.CLEAN_OPEN_TABS_STARTUP}`]: {
+      name: `${SettingID.CLEAN_OPEN_TABS_STARTUP}`,
       value: false,
     },
-    cleanExpiredCookies: {
-      name: 'cleanExpiredCookies',
+    [`${SettingID.CLEAN_EXPIRED}`]: {
+      name: `${SettingID.CLEAN_EXPIRED}`,
       value: false,
     },
-    contextMenus: {
-      name: 'contextMenus',
+    [`${SettingID.CONTEXT_MENUS}`]: {
+      name: `${SettingID.CONTEXT_MENUS}`,
       value: true,
     },
-    contextualIdentities: {
-      name: 'contextualIdentities',
+    [`${SettingID.CONTEXTUAL_IDENTITIES}`]: {
+      name: `${SettingID.CONTEXTUAL_IDENTITIES}`,
       value: false,
     },
-    debugMode: {
-      name: 'debugMode',
+    [`${SettingID.DEBUG_MODE}`]: {
+      name: `${SettingID.DEBUG_MODE}`,
       value: false,
     },
-    delayBeforeClean: {
-      name: 'delayBeforeClean',
+    [`${SettingID.CLEAN_DELAY}`]: {
+      name: `${SettingID.CLEAN_DELAY}`,
       value: 15,
     },
-    discardedCleanup: {
-      name: 'discardedCleanup',
+    [`${SettingID.CLEAN_DISCARDED}`]: {
+      name: `${SettingID.CLEAN_DISCARDED}`,
       value: false,
     },
-    domainChangeCleanup: {
-      name: 'domainChangeCleanup',
+    [`${SettingID.CLEAN_DOMAIN_CHANGE}`]: {
+      name: `${SettingID.CLEAN_DOMAIN_CHANGE}`,
       value: false,
     },
-    enableGreyListCleanup: {
-      name: 'enableGreyListCleanup',
+    [`${SettingID.ENABLE_GREYLIST}`]: {
+      name: `${SettingID.ENABLE_GREYLIST}`,
       value: true,
     },
-    enableNewVersionPopup: {
-      name: 'enableNewVersionPopup',
+    [`${SettingID.ENABLE_NEW_POPUP}`]: {
+      name: `${SettingID.ENABLE_NEW_POPUP}`,
       value: false,
     },
-    greyCleanLocalstorage: {
+    [`${SettingID.OLD_GREY_CLEAN_LOCALSTORAGE}`]: {
       id: 'DEPRECATED - use default expressions',
-      name: 'greyCleanLocalstorage',
+      name: `${SettingID.OLD_GREY_CLEAN_LOCALSTORAGE}`,
       value: false,
     },
-    indexedDBCleanup: {
-      name: 'indexedDBCleanup',
+    [`${SettingID.CLEANUP_INDEXEDDB}`]: {
+      name: `${SettingID.CLEANUP_INDEXEDDB}`,
       value: false,
     },
-    keepDefaultIcon: {
-      name: 'keepDefaultIcon',
+    [`${SettingID.KEEP_DEFAULT_ICON}`]: {
+      name: `${SettingID.KEEP_DEFAULT_ICON}`,
       value: false,
     },
-    localstorageCleanup: {
+    [`${SettingID.CLEANUP_LOCALSTORAGE_OLD}`]: {
       id: 'DEPRECATED - use localStorageCleanup',
-      name: 'localstorageCleanup',
+      name: `${SettingID.CLEANUP_LOCALSTORAGE_OLD}`,
       value: false,
     },
-    localStorageCleanup: {
-      name: 'localStorageCleanup',
+    [`${SettingID.CLEANUP_LOCALSTORAGE}`]: {
+      name: `${SettingID.CLEANUP_LOCALSTORAGE}`,
       value: false,
     },
-    manualNotifications: {
-      name: 'manualNotifications',
+    [`${SettingID.NOTIFY_MANUAL}`]: {
+      name: `${SettingID.NOTIFY_MANUAL}`,
       value: true,
     },
-    notificationOnScreen: {
-      name: 'notificationOnScreen',
+    [`${SettingID.NOTIFY_DURATION}`]: {
+      name: `${SettingID.NOTIFY_DURATION}`,
       value: 3,
     },
-    pluginDataCleanup: {
-      name: 'pluginDataCleanup',
+    [`${SettingID.CLEANUP_PLUGIN_DATA}`]: {
+      name: `${SettingID.CLEANUP_PLUGIN_DATA}`,
       value: false,
     },
-    serviceWorkersCleanup: {
-      name: 'serviceWorkersCleanup',
+    [`${SettingID.CLEANUP_SERVICE_WORKERS}`]: {
+      name: `${SettingID.CLEANUP_SERVICE_WORKERS}`,
       value: false,
     },
-    showNotificationAfterCleanup: {
-      name: 'showNotificationAfterCleanup',
+    [`${SettingID.NOTIFY_AUTO}`]: {
+      name: `${SettingID.NOTIFY_AUTO}`,
       value: true,
     },
-    showNumOfCookiesInIcon: {
-      name: 'showNumOfCookiesInIcon',
+    [`${SettingID.NUM_COOKIES_ICON}`]: {
+      name: `${SettingID.NUM_COOKIES_ICON}`,
       value: true,
     },
-    sizePopup: {
-      name: 'sizePopup',
+    [`${SettingID.SIZE_POPUP}`]: {
+      name: `${SettingID.SIZE_POPUP}`,
       value: 16,
     },
-    sizeSetting: {
-      name: 'sizeSetting',
+    [`${SettingID.SIZE_SETTING}`]: {
+      name: `${SettingID.SIZE_SETTING}`,
       value: 16,
     },
-    statLogging: {
-      name: 'statLogging',
+    [`${SettingID.STAT_LOGGING}`]: {
+      name: `${SettingID.STAT_LOGGING}`,
       value: true,
     },
-    whiteCleanLocalstorage: {
+    [`${SettingID.OLD_WHITE_CLEAN_LOCALSTORAGE}`]: {
       id: 'DEPRECATED - use default expressions',
-      name: 'whiteCleanLocalstorage',
+      name: `${SettingID.OLD_WHITE_CLEAN_LOCALSTORAGE}`,
       value: false,
     },
   },

--- a/src/services/AlarmEvents.ts
+++ b/src/services/AlarmEvents.ts
@@ -18,7 +18,10 @@ import StoreUser from './StoreUser';
 export default class AlarmEvents extends StoreUser {
   public static createActiveModeAlarm = async (): Promise<void> => {
     const seconds = parseInt(
-      getSetting(StoreUser.store.getState(), 'delayBeforeClean') as string,
+      getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.CLEAN_DELAY}`,
+      ) as string,
       10,
     );
     const milliseconds = (seconds > 0 ? seconds : 0.5) * 1000;
@@ -27,7 +30,7 @@ export default class AlarmEvents extends StoreUser {
     }
     AlarmEvents.alarmFlag = true;
     await sleep(milliseconds);
-    if (getSetting(StoreUser.store.getState(), 'activeMode')) {
+    if (getSetting(StoreUser.store.getState(), `${SettingID.ACTIVE_MODE}`)) {
       StoreUser.store.dispatch<any>(
         cookieCleanup({
           greyCleanup: false,

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -131,7 +131,7 @@ export const checkIfProtected = async (
   tab: browser.tabs.Tab | undefined = undefined,
   cookieLength?: number,
 ): Promise<void> => {
-  const active = state.settings.activeMode.value as boolean;
+  const active = state.settings[`${SettingID.ACTIVE_MODE}`].value as boolean;
   let activeTabs: browser.tabs.Tab[] = [];
 
   if (tab) {
@@ -181,7 +181,7 @@ export const checkIfProtected = async (
           if (active) {
             setIconColor(
               aTab,
-              state.settings.keepDefaultIcon.value as boolean,
+              state.settings[`${SettingID.KEEP_DEFAULT_ICON}`].value as boolean,
               'yellow',
             );
           } else {
@@ -192,7 +192,7 @@ export const checkIfProtected = async (
           if (active) {
             setIconColor(
               aTab,
-              state.settings.keepDefaultIcon.value as boolean,
+              state.settings[`${SettingID.KEEP_DEFAULT_ICON}`].value as boolean,
               'red',
             );
           } else {
@@ -211,7 +211,7 @@ export const checkIfProtected = async (
         if (active) {
           setIconColor(
             aTab,
-            state.settings.keepDefaultIcon.value as boolean,
+            state.settings[`${SettingID.KEEP_DEFAULT_ICON}`].value as boolean,
             'red',
           );
         } else {

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -75,7 +75,7 @@ export const isSafeToClean = (
   cookieProperties: CookiePropertiesCleanup,
   cleanupProperties: CleanupPropertiesInternal,
 ): CleanReasonObject => {
-  const debug = getSetting(state, 'debugMode') as boolean;
+  const debug = getSetting(state, `${SettingID.DEBUG_MODE}`) as boolean;
   const {
     mainDomain,
     storeId,
@@ -107,7 +107,7 @@ export const isSafeToClean = (
   );
 
   // Check if cookie is expired.
-  if (getSetting(state, 'cleanExpiredCookies') as boolean) {
+  if (getSetting(state, `${SettingID.CLEAN_EXPIRED}`) as boolean) {
     const now = Math.ceil(Date.now() / 1000);
     if (expirationDate && expirationDate < now) {
       cadLog(
@@ -309,7 +309,7 @@ export const cleanCookies = async (
           'CleanupService.cleanCookies: Cookie being removed through browser.cookies.remove via Promises:',
         x: cookieRemove,
       },
-      getSetting(state, 'debugMode') as boolean,
+      getSetting(state, `${SettingID.DEBUG_MODE}`) as boolean,
     );
     const promise = browser.cookies.remove(cookieRemove);
     promiseArr.push(promise);
@@ -358,7 +358,7 @@ export const clearCookiesForThisDomain = async (
     }
     showNotification(
       {
-        duration: getSetting(state, 'notificationOnScreen') as number,
+        duration: getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
         msg: `${browser.i18n.getMessage('manualCleanSuccess', [
           browser.i18n.getMessage('cookiesText'),
           hostname,
@@ -367,7 +367,7 @@ export const clearCookiesForThisDomain = async (
           cookies.length.toString(),
         ])}`,
       },
-      getSetting(state, 'manualNotifications') as boolean,
+      getSetting(state, `${SettingID.NOTIFY_MANUAL}`) as boolean,
     );
 
     return cookieDeletedCount > 0;
@@ -375,13 +375,13 @@ export const clearCookiesForThisDomain = async (
 
   showNotification(
     {
-      duration: getSetting(state, 'notificationOnScreen') as number,
+      duration: getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
       msg: `${browser.i18n.getMessage('manualCleanNothing', [
         browser.i18n.getMessage('cookiesText'),
         hostname,
       ])}`,
     },
-    getSetting(state, 'manualNotifications') as boolean,
+    getSetting(state, `${SettingID.NOTIFY_MANUAL}`) as boolean,
   );
 
   return cookies.length > 0;
@@ -404,7 +404,7 @@ export const clearLocalStorageForThisDomain = async (
     });
     showNotification(
       {
-        duration: getSetting(state, 'notificationOnScreen') as number,
+        duration: getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
         msg: `${browser.i18n.getMessage('manualCleanSuccess', [
           browser.i18n.getMessage('localStorageText'),
           getHostname(tab.url),
@@ -416,17 +416,17 @@ export const clearLocalStorageForThisDomain = async (
           browser.i18n.getMessage('sessionStorageText'),
         ])}`,
       },
-      getSetting(state, 'manualNotifications') as boolean,
+      getSetting(state, `${SettingID.NOTIFY_MANUAL}`) as boolean,
     );
     return true;
   } catch (e) {
     throwErrorNotification(
       e,
-      getSetting(state, 'notificationOnScreen') as number,
+      getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
     );
     await sleep(750);
     showNotification({
-      duration: getSetting(state, 'notificationOnScreen') as number,
+      duration: getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
       msg: `${browser.i18n.getMessage('manualCleanNothing', [
         browser.i18n.getMessage('localStorageText'),
         getHostname(tab.url),
@@ -442,7 +442,7 @@ export const clearSiteDataForThisDomain = async (
   hostname: string,
 ): Promise<boolean> => {
   if (hostname.trim() === '') return false;
-  const debug = getSetting(state, 'debugMode') as boolean;
+  const debug = getSetting(state, `${SettingID.DEBUG_MODE}`) as boolean;
   cadLog(
     {
       msg: `CleanupService.clearSiteDataForThisDomain: Received ${siteData} clean request for ${hostname}.`,
@@ -466,14 +466,14 @@ export const clearSiteDataForThisDomain = async (
     // To consolidate the notification shown, we do it out here.
     showNotification(
       {
-        duration: getSetting(state, 'notificationOnScreen') as number,
+        duration: getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
         msg: browser.i18n.getMessage('activityLogSiteDataDomainsText', [
           siteDataAll.join(', '),
           domains.join(', '),
         ]),
         title: browser.i18n.getMessage('notificationTitleSiteData'),
       },
-      getSetting(state, 'manualNotifications') as boolean,
+      getSetting(state, `${SettingID.NOTIFY_MANUAL}`) as boolean,
     );
   } else {
     await removeSiteData(
@@ -525,14 +525,14 @@ export const removeSiteData = async (
     );
     showNotification(
       {
-        duration: getSetting(state, 'notificationOnScreen') as number,
+        duration: getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
         msg: browser.i18n.getMessage('activityLogSiteDataDomainsText', [
           browser.i18n.getMessage(`${sd}Text`),
           domains.join(', '),
         ]),
         title: browser.i18n.getMessage('notificationTitleSiteData'),
       },
-      manual && (getSetting(state, 'manualNotifications') as boolean),
+      manual && (getSetting(state, `${SettingID.NOTIFY_MANUAL}`) as boolean),
     );
     return true;
   } catch (e) {
@@ -546,7 +546,7 @@ export const removeSiteData = async (
     );
     throwErrorNotification(
       e,
-      getSetting(state, 'notificationOnScreen') as number,
+      getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
     );
     return false;
   }
@@ -558,10 +558,10 @@ export const otherBrowsingDataCleanup = async (
   isSafeToCleanObjects: CleanReasonObject[],
 ): Promise<ActivityLog['browsingDataCleanup']> => {
   const chrome = isChrome(state.cache);
-  const debug = getSetting(state, 'debugMode') as boolean;
+  const debug = getSetting(state, `${SettingID.DEBUG_MODE}`) as boolean;
   const browsingDataResult: ActivityLog['browsingDataCleanup'] = {};
   if (
-    getSetting(state, 'cacheCleanup') &&
+    getSetting(state, `${SettingID.CLEANUP_CACHE}`) &&
     ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '78') ||
       chrome)
   ) {
@@ -574,7 +574,7 @@ export const otherBrowsingDataCleanup = async (
     );
   }
   if (
-    getSetting(state, 'indexedDBCleanup') &&
+    getSetting(state, `${SettingID.CLEANUP_INDEXEDDB}`) &&
     ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '77') ||
       chrome)
   ) {
@@ -587,7 +587,7 @@ export const otherBrowsingDataCleanup = async (
     );
   }
   if (
-    getSetting(state, 'localStorageCleanup') &&
+    getSetting(state, `${SettingID.CLEANUP_LOCALSTORAGE}`) &&
     ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '58') ||
       chrome)
   ) {
@@ -600,7 +600,7 @@ export const otherBrowsingDataCleanup = async (
     );
   }
   if (
-    getSetting(state, 'pluginDataCleanup') &&
+    getSetting(state, `${SettingID.CLEANUP_PLUGIN_DATA}`) &&
     ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '78') ||
       chrome)
   ) {
@@ -613,7 +613,7 @@ export const otherBrowsingDataCleanup = async (
     );
   }
   if (
-    getSetting(state, 'serviceWorkersCleanup') &&
+    getSetting(state, `${SettingID.CLEANUP_SERVICE_WORKERS}`) &&
     ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '77') ||
       chrome)
   ) {
@@ -768,7 +768,7 @@ export const cleanCookiesOperation = async (
     ignoreOpenTabs: false,
   },
 ): Promise<Record<string, any>> => {
-  const debug = getSetting(state, 'debugMode') as boolean;
+  const debug = getSetting(state, `${SettingID.DEBUG_MODE}`) as boolean;
   const deletedSiteDataArrays: ActivityLog['browsingDataCleanup'] = {};
   const setOfDeletedDomainCookies = new Set<string>();
   const cachedResults: Required<ActivityLog> = {
@@ -782,7 +782,7 @@ export const cleanCookiesOperation = async (
   const storesIdsToScrub = ['firefox-private', 'private', '1'];
   const openTabDomains = await returnContainersOfOpenTabDomains(
     cleanupProperties.ignoreOpenTabs,
-    getSetting(state, 'discardedCleanup') as boolean,
+    getSetting(state, `${SettingID.CLEAN_DISCARDED}`) as boolean,
   );
   const newCleanupProperties: CleanupPropertiesInternal = {
     ...cleanupProperties,
@@ -813,7 +813,7 @@ export const cleanCookiesOperation = async (
   }
 
   // Store cookieStoreIds from the contextualIdentities API
-  if (getSetting(state, 'contextualIdentities')) {
+  if (getSetting(state, `${SettingID.CONTEXTUAL_IDENTITIES}`)) {
     const contextualIdentitiesObjects = await browser.contextualIdentities.query(
       {},
     );
@@ -827,7 +827,7 @@ export const cleanCookiesOperation = async (
   const cookieStores = (await browser.cookies.getAllCookieStores()) || [];
   for (const store of cookieStores) {
     if (
-      getSetting(state, 'contextualIdentities') ||
+      getSetting(state, `${SettingID.CONTEXTUAL_IDENTITIES}`) ||
       !store.id.startsWith('firefox-container')
     ) {
       cookieStoreIds.add(store.id);
@@ -930,7 +930,7 @@ export const cleanCookiesOperation = async (
       );
       throwErrorNotification(
         e,
-        getSetting(state, 'notificationOnScreen') as number,
+        getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
       );
     }
 
@@ -945,7 +945,7 @@ export const cleanCookiesOperation = async (
     cachedResults.recentlyCleaned += removedCookies.length;
     removedCookies.forEach((obj) => {
       setOfDeletedDomainCookies.add(
-        getSetting(state, 'contextualIdentities')
+        getSetting(state, `${SettingID.CONTEXTUAL_IDENTITIES}`)
           ? `${obj.cookie.hostname} (${state.cache[obj.cookie.storeId]})`
           : obj.cookie.hostname,
       );

--- a/src/services/ContextMenuEvents.ts
+++ b/src/services/ContextMenuEvents.ts
@@ -65,7 +65,12 @@ export default class ContextMenuEvents extends StoreUser {
 
   public static menuInit(): void {
     if (!browser.contextMenus) return;
-    if (!getSetting(StoreUser.store.getState(), 'contextMenus') as boolean)
+    if (
+      !getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.CONTEXT_MENUS}`,
+      ) as boolean
+    )
       return;
     if (ContextMenuEvents.isInitialized) return;
     ContextMenuEvents.isInitialized = true;
@@ -235,7 +240,7 @@ export default class ContextMenuEvents extends StoreUser {
     });
     // Active Mode
     ContextMenuEvents.menuCreate({
-      checked: getSetting(StoreUser.store.getState(), 'activeMode') as boolean,
+      checked: getSetting(StoreUser.store.getState(),`${SettingID.ACTIVE_MODE}`) as boolean,
       id: ContextMenuEvents.MenuID.ACTIVE_MODE,
       title: browser.i18n.getMessage('activeModeText'),
       type: 'checkbox',
@@ -265,7 +270,10 @@ export default class ContextMenuEvents extends StoreUser {
       {
         msg: `ContextMenuEvents.menuClear:  Context Menu has been removed.`,
       },
-      getSetting(StoreUser.store.getState(), 'debugMode') as boolean,
+      getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.DEBUG_MODE}`,
+      ) as boolean,
     );
   }
 
@@ -294,14 +302,17 @@ export default class ContextMenuEvents extends StoreUser {
         msg: `ContextMenuEvents.updateMenuItemCheckbox: Updated Menu Item.`,
         x: { id, checked },
       },
-      getSetting(StoreUser.store.getState(), 'debugMode') as boolean,
+      getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.DEBUG_MODE}`,
+      ) as boolean,
     );
   }
 
   public static onCreatedOrUpdated(): void {
     const debug = getSetting(
       StoreUser.store.getState(),
-      'debugMode',
+      `${SettingID.DEBUG_MODE}`,
     ) as boolean;
     if (browser.runtime.lastError) {
       cadLog(
@@ -327,11 +338,11 @@ export default class ContextMenuEvents extends StoreUser {
   ): Promise<void> {
     const debug = getSetting(
       StoreUser.store.getState(),
-      'debugMode',
+      `${SettingID.DEBUG_MODE}`,
     ) as boolean;
     const contextualIdentities = getSetting(
       StoreUser.store.getState(),
-      'contextualIdentities',
+      `${SettingID.CONTEXTUAL_IDENTITIES}`,
     ) as boolean;
     cadLog(
       {
@@ -363,7 +374,7 @@ export default class ContextMenuEvents extends StoreUser {
         showNotification({
           duration: getSetting(
             StoreUser.store.getState(),
-            'notificationOnScreen',
+            `${SettingID.NOTIFY_DURATION}`,
           ) as number,
           msg: `${browser.i18n.getMessage('manualCleanError', [
             browser.i18n.getMessage(
@@ -767,7 +778,7 @@ export default class ContextMenuEvents extends StoreUser {
           // Setting Updated.
           StoreUser.store.dispatch<any>(
             updateSetting({
-              name: 'activeMode',
+              name: `${SettingID.ACTIVE_MODE}`,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               value: info.checked!,
             }),
@@ -808,7 +819,7 @@ export default class ContextMenuEvents extends StoreUser {
       showNotification({
         duration: getSetting(
           StoreUser.store.getState(),
-          'notificationOnScreen',
+          `${SettingID.NOTIFY_DURATION}`,
         ) as number,
         msg: `${browser.i18n.getMessage('addNewExpressionNotificationFailed')}`,
       });
@@ -820,7 +831,7 @@ export default class ContextMenuEvents extends StoreUser {
       storeId: parseCookieStoreId(
         getSetting(
           StoreUser.store.getState(),
-          'contextualIdentities',
+          `${SettingID.CONTEXTUAL_IDENTITIES}`,
         ) as boolean,
         cookieStoreId,
       ),
@@ -830,13 +841,16 @@ export default class ContextMenuEvents extends StoreUser {
         msg: `background.addNewExpression - Parsed from Right-Click:`,
         x: payload,
       },
-      getSetting(StoreUser.store.getState(), 'debugMode') as boolean,
+      getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.DEBUG_MODE}`,
+      ) as boolean,
     );
     const cache = StoreUser.store.getState().cache;
     showNotification({
       duration: getSetting(
         StoreUser.store.getState(),
-        'notificationOnScreen',
+        `${SettingID.NOTIFY_DURATION}`,
       ) as number,
       msg: `${browser.i18n.getMessage('addNewExpressionNotification', [
         payload.expression,
@@ -844,7 +858,7 @@ export default class ContextMenuEvents extends StoreUser {
         `${payload.storeId}${
           (getSetting(
             StoreUser.store.getState(),
-            'contextualIdentities',
+            `${SettingID.CONTEXTUAL_IDENTITIES}`,
           ) as boolean)
             ? cache[payload.storeId] !== undefined
               ? ` (${cache[payload.storeId]})`

--- a/src/services/ContextMenuEvents.ts
+++ b/src/services/ContextMenuEvents.ts
@@ -23,6 +23,7 @@ import {
 } from './CleanupService';
 import {
   cadLog,
+  eventListenerActions,
   getHostname,
   getSetting,
   localFileToRegex,
@@ -245,21 +246,19 @@ export default class ContextMenuEvents extends StoreUser {
       title: browser.i18n.getMessage('settingsText'),
     });
 
-    if (
-      !browser.contextMenus.onClicked.hasListener(
-        ContextMenuEvents.onContextMenuClicked,
-      )
-    ) {
-      browser.contextMenus.onClicked.addListener(
-        ContextMenuEvents.onContextMenuClicked,
-      );
-    }
+    eventListenerActions(
+      browser.contextMenus.onClicked,
+      ContextMenuEvents.onContextMenuClicked,
+      EventListenerAction.ADD,
+    );
   }
 
   public static async menuClear(): Promise<void> {
     await browser.contextMenus.removeAll();
-    browser.contextMenus.onClicked.removeListener(
+    eventListenerActions(
+      browser.contextMenus.onClicked,
       ContextMenuEvents.onContextMenuClicked,
+      EventListenerAction.REMOVE,
     );
     ContextMenuEvents.isInitialized = false;
     cadLog(

--- a/src/services/ContextualIdentitiesEvents.ts
+++ b/src/services/ContextualIdentitiesEvents.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2020 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import StoreUser from './StoreUser';
+import { cacheCookieStoreIdNames, removeListUI } from '../redux/Actions';
+import contextualIdentitiesChangeInfo = browser.contextualIdentities.contextualIdentitiesChangeInfo;
+import { cadLog, eventListenerActions, getSetting } from './Libs';
+import { ReduxConstants } from '../typings/ReduxConstants';
+
+export default class ContextualIdentitiesEvents extends StoreUser {
+  public static init(): void {
+    if (!browser.contextualIdentities) return;
+    if (
+      !getSetting(StoreUser.store.getState(), 'contextualIdentities') as boolean
+    )
+      return;
+    if (ContextualIdentitiesEvents.isInitialized) return;
+    ContextualIdentitiesEvents.isInitialized = true;
+    // Populate cache with mapped Container ID to Name
+    StoreUser.store.dispatch<any>(cacheCookieStoreIdNames());
+    eventListenerActions(
+      browser.contextualIdentities.onCreated,
+      ContextualIdentitiesEvents.onContainerCreated,
+      EventListenerAction.ADD,
+    );
+    eventListenerActions(
+      browser.contextualIdentities.onRemoved,
+      ContextualIdentitiesEvents.onContainerRemoved,
+      EventListenerAction.ADD,
+    );
+    eventListenerActions(
+      browser.contextualIdentities.onUpdated,
+      ContextualIdentitiesEvents.onContainerUpdated,
+      EventListenerAction.ADD,
+    );
+    cadLog(
+      {
+        msg: `ContextualIdentitiesEvents.deInit:  Container Events have been added.`,
+      },
+      getSetting(StoreUser.store.getState(), 'debugMode') as boolean,
+    );
+  }
+
+  /**
+   * This removes all related event listeners and attempts to 'un-define' existing containers.
+   */
+  public static async deInit(): Promise<void> {
+    if (!ContextualIdentitiesEvents.isInitialized) return;
+    eventListenerActions(
+      browser.contextualIdentities.onCreated,
+      ContextualIdentitiesEvents.onContainerCreated,
+      EventListenerAction.REMOVE,
+    );
+    eventListenerActions(
+      browser.contextualIdentities.onRemoved,
+      ContextualIdentitiesEvents.onContainerRemoved,
+      EventListenerAction.REMOVE,
+    );
+    eventListenerActions(
+      browser.contextualIdentities.onUpdated,
+      ContextualIdentitiesEvents.onContainerUpdated,
+      EventListenerAction.REMOVE,
+    );
+    ContextualIdentitiesEvents.isInitialized = false;
+    const existingContainers = await browser.contextualIdentities.query({});
+    for (const ci of existingContainers) {
+      StoreUser.store.dispatch({
+        payload: {
+          key: ci.cookieStoreId,
+          value: undefined,
+        },
+        type: ReduxConstants.ADD_CACHE,
+      });
+    }
+    cadLog(
+      {
+        msg: `ContextualIdentitiesEvents.deInit:  Container Events have been removed.`,
+      },
+      getSetting(StoreUser.store.getState(), 'debugMode') as boolean,
+    );
+  }
+
+  /**
+   * This will add the new container mapping to the cache.
+   * @param changeInfo The ContextualIdentity object that was created.
+   */
+  public static onContainerCreated(
+    changeInfo: contextualIdentitiesChangeInfo,
+  ): void {
+    StoreUser.store.dispatch({
+      payload: {
+        key: changeInfo.contextualIdentity.cookieStoreId,
+        value: changeInfo.contextualIdentity.name,
+      },
+      type: ReduxConstants.ADD_CACHE,
+    });
+  }
+
+  /**
+   * This should remove the related cookieStoreId/container when removed in Firefox.
+   * @param changeInfo The ContextualIdentity Object that was removed.
+   */
+  public static onContainerRemoved(
+    changeInfo: contextualIdentitiesChangeInfo,
+  ): void {
+    StoreUser.store.dispatch(
+      removeListUI(changeInfo.contextualIdentity.cookieStoreId),
+    );
+    StoreUser.store.dispatch({
+      payload: {
+        key: changeInfo.contextualIdentity.cookieStoreId,
+        value: undefined,
+      },
+      type: ReduxConstants.ADD_CACHE,
+    });
+  }
+
+  /**
+   * This should update the cache if a container was updated in Firefox.
+   * @param changeInfo The ContextualIdentity Object that was updated.
+   */
+  public static onContainerUpdated(
+    changeInfo: contextualIdentitiesChangeInfo,
+  ): void {
+    const cache = StoreUser.store.getState().cache;
+    if (
+      cache[changeInfo.contextualIdentity.cookieStoreId] &&
+      cache[changeInfo.contextualIdentity.cookieStoreId] !==
+        changeInfo.contextualIdentity.name
+    ) {
+      StoreUser.store.dispatch({
+        payload: {
+          key: changeInfo.contextualIdentity.cookieStoreId,
+          value: changeInfo.contextualIdentity.name,
+        },
+        type: ReduxConstants.ADD_CACHE,
+      });
+    }
+  }
+
+  protected static isInitialized = false;
+}

--- a/src/services/ContextualIdentitiesEvents.ts
+++ b/src/services/ContextualIdentitiesEvents.ts
@@ -21,7 +21,10 @@ export default class ContextualIdentitiesEvents extends StoreUser {
   public static init(): void {
     if (!browser.contextualIdentities) return;
     if (
-      !getSetting(StoreUser.store.getState(), 'contextualIdentities') as boolean
+      !getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.CONTEXTUAL_IDENTITIES}`,
+      ) as boolean
     )
       return;
     if (ContextualIdentitiesEvents.isInitialized) return;
@@ -47,7 +50,10 @@ export default class ContextualIdentitiesEvents extends StoreUser {
       {
         msg: `ContextualIdentitiesEvents.deInit:  Container Events have been added.`,
       },
-      getSetting(StoreUser.store.getState(), 'debugMode') as boolean,
+      getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.DEBUG_MODE}`,
+      ) as boolean,
     );
   }
 
@@ -86,7 +92,10 @@ export default class ContextualIdentitiesEvents extends StoreUser {
       {
         msg: `ContextualIdentitiesEvents.deInit:  Container Events have been removed.`,
       },
-      getSetting(StoreUser.store.getState(), 'debugMode') as boolean,
+      getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.DEBUG_MODE}`,
+      ) as boolean,
     );
   }
 

--- a/src/services/ContextualIdentitiesEvents.ts
+++ b/src/services/ContextualIdentitiesEvents.ts
@@ -19,15 +19,15 @@ import { ReduxConstants } from '../typings/ReduxConstants';
 
 export default class ContextualIdentitiesEvents extends StoreUser {
   public static init(): void {
-    if (!browser.contextualIdentities) return;
     if (
-      !getSetting(
+      !browser.contextualIdentities ||
+      (!getSetting(
         StoreUser.store.getState(),
         `${SettingID.CONTEXTUAL_IDENTITIES}`,
-      ) as boolean
+      ) as boolean) ||
+      ContextualIdentitiesEvents.isInitialized
     )
       return;
-    if (ContextualIdentitiesEvents.isInitialized) return;
     ContextualIdentitiesEvents.isInitialized = true;
     // Populate cache with mapped Container ID to Name
     StoreUser.store.dispatch<any>(cacheCookieStoreIdNames());

--- a/src/services/CookieEvents.ts
+++ b/src/services/CookieEvents.ts
@@ -29,12 +29,15 @@ export default class CookieEvents extends StoreUser {
       windowType: 'normal',
     });
     tabQuery.forEach((tab) => {
+      // Tabs.id with tabs.TAB_ID_NONE do not host content tabs
+      // Tabs.url is always present as we already have the 'tabs' permission.
+      if (!tab.id || !tab.url) return;
       if (
-        extractMainDomain(getHostname(tab.url || '')) ===
+        extractMainDomain(getHostname(tab.url)) ===
         extractMainDomain(changeInfo.cookie.domain)
       ) {
         // Force Tab Update function
-        TabEvents.onTabUpdate(tab.id || 0, { cookieChanged: changeInfo }, tab);
+        TabEvents.onTabUpdate(tab.id, { cookieChanged: changeInfo }, tab);
       }
     });
   }

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -105,6 +105,32 @@ export const convertVersionToNumber = (version?: string): number => {
 };
 
 /**
+ * Abstract Event Listener call to add/remove with checks.
+ * @param event The event listener
+ * @param listener The callback function to add/check/remove.
+ * @param action The EventListenerAction (add/remove).
+ */
+export const eventListenerActions = (
+  event: EvListener<any>,
+  listener: (...args: any[]) => void,
+  action: EventListenerAction,
+): void => {
+  if (!event) return;
+  switch (action) {
+    case EventListenerAction.ADD:
+      if (!event.hasListener(listener)) {
+        event.addListener(listener);
+      }
+      break;
+    case EventListenerAction.REMOVE:
+      if (event.hasListener(listener)) {
+        event.removeListener(listener);
+      }
+      break;
+  }
+};
+
+/**
  * Extract the main domain from sub domains
  *   - sub.sub.domain.com ==> domain.com
  * Local html directory/files will return itself

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -116,6 +116,7 @@ export const eventListenerActions = (
   action: EventListenerAction,
 ): void => {
   if (!event) return;
+  if (!event.hasListener) return;
   switch (action) {
     case EventListenerAction.ADD:
       if (!event.hasListener(listener)) {
@@ -393,7 +394,8 @@ export const getContainerExpressionDefault = (
     storeId: '',
   };
   const expDefault =
-    storeId !== 'default' && getSetting(state, 'contextualIdentities')
+    storeId !== 'default' &&
+    getSetting(state, `${SettingID.CONTEXTUAL_IDENTITIES}`)
       ? getExpression('default') || exp
       : exp;
   return getExpression(storeId) || expDefault;
@@ -413,7 +415,7 @@ export const getSetting = (
 export const getStoreId = (state: State, storeId: string): string => {
   if (
     storeId === 'firefox-default' ||
-    (!getSetting(state, 'contextualIdentities') &&
+    (!getSetting(state, `${SettingID.CONTEXTUAL_IDENTITIES}`) &&
       storeId !== 'firefox-private' &&
       isFirefox(state.cache)) ||
     (isChrome(state.cache) && storeId === '0') ||

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -189,7 +189,7 @@ export const getAllCookiesForDomain = async (
 ): Promise<browser.cookies.Cookie[] | undefined> => {
   if (!tab.url || tab.url === '') return;
   if (tab.url.startsWith('about:') || tab.url.startsWith('chrome:')) return;
-  const debug = getSetting(state, 'debugMode') as boolean;
+  const debug = getSetting(state, SettingID.DEBUG_MODE) as boolean;
   const partialTabInfo = createPartialTabInfo(tab);
   const { cookieStoreId, url } = tab;
   const hostname = getHostname(url);

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -115,8 +115,7 @@ export const eventListenerActions = (
   listener: (...args: any[]) => void,
   action: EventListenerAction,
 ): void => {
-  if (!event) return;
-  if (!event.hasListener) return;
+  if (!event || !event.hasListener) return;
   switch (action) {
     case EventListenerAction.ADD:
       if (!event.hasListener(listener)) {

--- a/src/services/SettingService.ts
+++ b/src/services/SettingService.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2020 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import StoreUser from './StoreUser';
+import ContextualIdentitiesEvents from './ContextualIdentitiesEvents';
+import { cacheCookieStoreIdNames, validateSettings } from '../redux/Actions';
+import { cadLog, siteDataToBrowser, SITEDATATYPES } from './Libs';
+import { checkIfProtected, setGlobalIcon } from './BrowserActionService';
+import ContextMenuEvents from './ContextMenuEvents';
+import { ReduxConstants } from '../typings/ReduxConstants';
+
+export default class SettingService extends StoreUser {
+  public static init(): void {
+    SettingService.current = StoreUser.store.getState().settings;
+    SettingService.isInitialized = true;
+  }
+
+  public static async onSettingsChange(): Promise<void> {
+    if (!SettingService.isInitialized) {
+      SettingService.init();
+    }
+    const previous = SettingService.current;
+    SettingService.current = StoreUser.store.getState().settings;
+
+    // Container Mode Changes
+    if (SettingService.hasNewValue(previous, SettingID.CONTEXTUAL_IDENTITIES)) {
+      if (SettingService.getCurrent(SettingID.CONTEXTUAL_IDENTITIES)) {
+        ContextualIdentitiesEvents.init();
+        StoreUser.store.dispatch<any>(cacheCookieStoreIdNames());
+      } else {
+        await ContextualIdentitiesEvents.deInit();
+      }
+    }
+
+    // BrowsingData Settings Check
+    for (const siteData of SITEDATATYPES) {
+      const sd = `${siteDataToBrowser(siteData)}Cleanup`;
+      if (
+        (previous[sd] === undefined || !previous[sd].value) &&
+        SettingService.current[sd].value
+      ) {
+        // Migration Check to prevent LocalStorage from being cleaned again.
+        // Only if migrating from 3.4.0 to 3.5.1+
+        if (
+          siteData === SiteDataType.LOCALSTORAGE &&
+          previous[SettingID.CLEANUP_LOCALSTORAGE_OLD] !== undefined &&
+          previous[SettingID.CLEANUP_LOCALSTORAGE_OLD].value
+        ) {
+          continue;
+        }
+        await browser.browsingData.remove(
+          { since: 0 },
+          { [siteDataToBrowser(siteData)]: true },
+        );
+        cadLog(
+          {
+            msg: `${siteData} setting activated.  All previous ${siteData} has been cleared for a clean slate.`,
+            type: 'info',
+          },
+          SettingService.getCurrent(SettingID.DEBUG_MODE) as boolean,
+        );
+      }
+    }
+
+    // Active Mode (Automatic Cleanup) changes
+    if (SettingService.hasNewValue(previous, SettingID.ACTIVE_MODE)) {
+      const active = SettingService.getCurrent(
+        SettingID.ACTIVE_MODE,
+      ) as boolean;
+      if (!active) {
+        await browser.alarms.clear('activeModeAlarm');
+      }
+      await setGlobalIcon(active);
+      ContextMenuEvents.updateMenuItemCheckbox(
+        ContextMenuEvents.MenuID.ACTIVE_MODE,
+        active,
+      );
+    }
+
+    // Context Menu Changes
+    if (SettingService.hasNewValue(previous, SettingID.CONTEXT_MENUS)) {
+      if (SettingService.getCurrent(SettingID.CONTEXT_MENUS)) {
+        ContextMenuEvents.menuInit();
+      } else {
+        await ContextMenuEvents.menuClear();
+      }
+    }
+
+    // Deprecated Setting Adjustments
+    // Only for localstorageCleanup <-> localStorageCleanup
+    SettingService.updateDeprecatedSetting(
+      previous,
+      SettingID.CLEANUP_LOCALSTORAGE,
+      SettingID.CLEANUP_LOCALSTORAGE_OLD,
+    );
+    SettingService.updateDeprecatedSetting(
+      previous,
+      SettingID.CLEANUP_LOCALSTORAGE_OLD,
+      SettingID.CLEANUP_LOCALSTORAGE,
+    );
+
+    await checkIfProtected(StoreUser.store.getState());
+
+    // Validate Settings Again
+    StoreUser.store.dispatch<any>(validateSettings());
+  }
+
+  private static getCurrent(s: SettingID): boolean | number | string {
+    return SettingService.current[s].value;
+  }
+
+  private static hasNewValue(p: MapToSettingObject, s: SettingID): boolean {
+    return p[s].value !== SettingService.current[s].value;
+  }
+
+  private static updateDeprecatedSetting(
+    p: MapToSettingObject,
+    a: SettingID,
+    b: SettingID,
+  ): void {
+    if (p[a] && SettingService.current[a] && SettingService.hasNewValue(p, a)) {
+      StoreUser.store.dispatch({
+        payload: {
+          name: b,
+          value: SettingService.getCurrent(a),
+        },
+        type: ReduxConstants.UPDATE_SETTING,
+      });
+    }
+  }
+
+  protected static current: MapToSettingObject;
+  protected static delaySave = false;
+  protected static isInitialized = false;
+}

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -37,10 +37,12 @@ export default class TabEvents extends StoreUser {
     changeInfo: browser.tabs.TabChangeInfo,
     tab: browser.tabs.Tab,
   ): void {
-    if (getSetting(StoreUser.store.getState(), 'discardedCleanup')) {
+    if (
+      getSetting(StoreUser.store.getState(), `${SettingID.CLEAN_DISCARDED}`)
+    ) {
       const debug = getSetting(
         StoreUser.store.getState(),
-        'debugMode',
+        `${SettingID.DEBUG_MODE}`,
       ) as boolean;
       const partialTabInfo = createPartialTabInfo(tab);
       // Truncate ChangeInfo.favIconUrl as we have no use for it in debug.
@@ -76,7 +78,7 @@ export default class TabEvents extends StoreUser {
     if (tab.status === 'complete') {
       const debug = getSetting(
         StoreUser.store.getState(),
-        'debugMode',
+        `${SettingID.DEBUG_MODE}`,
       ) as boolean;
       const partialTabInfo = createPartialTabInfo(tab);
       // Truncate ChangeInfo.favIconUrl as we have no use for it in debug.
@@ -130,7 +132,7 @@ export default class TabEvents extends StoreUser {
   ): void {
     const debug = getSetting(
       StoreUser.store.getState(),
-      'debugMode',
+      `${SettingID.DEBUG_MODE}`,
     ) as boolean;
     if (tab.status === 'complete') {
       const partialTabInfo = createPartialTabInfo(tab);
@@ -158,7 +160,12 @@ export default class TabEvents extends StoreUser {
       ) {
         const oldMainDomain = TabEvents.tabToDomain[tabId];
         TabEvents.tabToDomain[tabId] = mainDomain;
-        if (getSetting(StoreUser.store.getState(), 'domainChangeCleanup')) {
+        if (
+          getSetting(
+            StoreUser.store.getState(),
+            `${SettingID.CLEAN_DOMAIN_CHANGE}`,
+          )
+        ) {
           if (oldMainDomain === '') {
             cadLog(
               {
@@ -226,7 +233,10 @@ export default class TabEvents extends StoreUser {
           'TabEvents.onDomainChangeRemove: Tab was closed.  Removing old tabToDomain info.',
         x: { tabId, mainDomain: TabEvents.tabToDomain[tabId], removeInfo },
       },
-      getSetting(StoreUser.store.getState(), 'debugMode') as boolean,
+      getSetting(
+        StoreUser.store.getState(),
+        `${SettingID.DEBUG_MODE}`,
+      ) as boolean,
     );
     delete TabEvents.tabToDomain[tabId];
   }
@@ -234,9 +244,9 @@ export default class TabEvents extends StoreUser {
   public static cleanFromTabEvents = async (): Promise<void> => {
     const debug = getSetting(
       StoreUser.store.getState(),
-      'debugMode',
+      `${SettingID.DEBUG_MODE}`,
     ) as boolean;
-    if (getSetting(StoreUser.store.getState(), 'activeMode')) {
+    if (getSetting(StoreUser.store.getState(), `${SettingID.ACTIVE_MODE}`)) {
       const alarm = await browser.alarms.get('activeModeAlarm');
       if (!alarm || (alarm.name && alarm.name !== 'activeModeAlarm')) {
         cadLog(
@@ -267,7 +277,7 @@ export default class TabEvents extends StoreUser {
     if (tab.url.startsWith('about:') || tab.url.startsWith('chrome:')) return;
     const debug = getSetting(
       StoreUser.store.getState(),
-      'debugMode',
+      `${SettingID.DEBUG_MODE}`,
     ) as boolean;
     const partialTabInfo = createPartialTabInfo(tab);
     const cookies = await getAllCookiesForDomain(
@@ -293,11 +303,23 @@ export default class TabEvents extends StoreUser {
 
     if (
       internalCookies.length === 0 &&
-      (getSetting(StoreUser.store.getState(), 'cacheCleanup') ||
-        getSetting(StoreUser.store.getState(), 'indexedDBCleanup') ||
-        getSetting(StoreUser.store.getState(), 'localStorageCleanup') ||
-        getSetting(StoreUser.store.getState(), 'pluginDataCleanup') ||
-        getSetting(StoreUser.store.getState(), 'serviceWorkersCleanup')) &&
+      (getSetting(StoreUser.store.getState(), `${SettingID.CLEANUP_CACHE}`) ||
+        getSetting(
+          StoreUser.store.getState(),
+          `${SettingID.CLEANUP_INDEXEDDB}`,
+        ) ||
+        getSetting(
+          StoreUser.store.getState(),
+          `${SettingID.CLEANUP_LOCALSTORAGE}`,
+        ) ||
+        getSetting(
+          StoreUser.store.getState(),
+          `${SettingID.CLEANUP_PLUGIN_DATA}`,
+        ) ||
+        getSetting(
+          StoreUser.store.getState(),
+          `${SettingID.CLEANUP_SERVICE_WORKERS}`,
+        )) &&
       isAWebpage(tab.url) &&
       !tab.url.startsWith('file:')
     ) {
@@ -348,7 +370,7 @@ export default class TabEvents extends StoreUser {
 
     // Exclude Firefox Android for browser icons and badge texts
     if (
-      getSetting(StoreUser.store.getState(), 'showNumOfCookiesInIcon') &&
+      getSetting(StoreUser.store.getState(), `${SettingID.NUM_COOKIES_ICON}`) &&
       (StoreUser.store.getState().cache.platformOs || '') !== 'android'
     ) {
       cadLog(

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -100,3 +100,8 @@ type CADLogItem = Readonly<{
   msg?: string;
   x?: any;
 }>;
+
+declare const enum EventListenerAction {
+  ADD = 'ADD',
+  REMOVE = 'REMOVE',
+}

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -79,6 +79,36 @@ type Setting = Readonly<{
   value: boolean | number | string;
 }>;
 
+declare const enum SettingID {
+  ACTIVE_MODE = 'activeMode',
+  CLEAN_DELAY = 'delayBeforeClean',
+  CLEAN_DISCARDED = 'discardedCleanup',
+  CLEAN_DOMAIN_CHANGE = 'domainChangeCleanup',
+  CLEAN_EXPIRED = 'cleanExpiredCookies',
+  CLEAN_OPEN_TABS_STARTUP = 'cleanCookiesFromOpenTabsOnStartup',
+  CLEANUP_CACHE = 'cacheCleanup',
+  CLEANUP_INDEXEDDB = 'indexedDBCleanup',
+  CLEANUP_LOCALSTORAGE = 'localStorageCleanup',
+  CLEANUP_LOCALSTORAGE_OLD = 'localstorageCleanup',
+  CLEANUP_PLUGIN_DATA = 'pluginDataCleanup',
+  CLEANUP_SERVICE_WORKERS = 'serviceWorkersCleanup',
+  CONTEXT_MENUS = 'contextMenus',
+  CONTEXTUAL_IDENTITIES = 'contextualIdentities',
+  DEBUG_MODE = 'debugMode',
+  ENABLE_GREYLIST = 'enableGreyListCleanup',
+  ENABLE_NEW_POPUP = 'enableNewVersionPopup',
+  KEEP_DEFAULT_ICON = 'keepDefaultIcon',
+  NOTIFY_AUTO = 'showNotificationAfterCleanup',
+  NOTIFY_MANUAL = 'manualNotifications',
+  NOTIFY_DURATION = 'notificationOnScreen',
+  NUM_COOKIES_ICON = 'showNumOfCookiesInIcon',
+  OLD_GREY_CLEAN_LOCALSTORAGE = 'greyCleanLocalstorage',
+  OLD_WHITE_CLEAN_LOCALSTORAGE = 'whiteCleanLocalstorage',
+  SIZE_POPUP = 'sizePopup',
+  SIZE_SETTING = 'sizeSetting',
+  STAT_LOGGING = 'statLogging',
+}
+
 declare const enum ListType {
   WHITE = 'WHITE',
   GREY = 'GREY',

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -135,3 +135,5 @@ declare const enum EventListenerAction {
   ADD = 'ADD',
   REMOVE = 'REMOVE',
 }
+
+type JestSpyObject = { [s: string]: jest.SpyInstance };

--- a/src/typings/Webext.d.ts
+++ b/src/typings/Webext.d.ts
@@ -51,6 +51,16 @@ declare namespace browser.contextMenus {
   const onShown: typeof browser.menus.onShown;
 }
 
+// Until web-ext-types land events into it.
+declare namespace browser.contextualIdentities {
+  type contextualIdentitiesChangeInfo = {
+    contextualIdentity: ContextualIdentity;
+  };
+  const onCreated: Listener<contextualIdentitiesChangeInfo>;
+  const onRemoved: Listener<contextualIdentitiesChangeInfo>;
+  const onUpdated: Listener<contextualIdentitiesChangeInfo>;
+}
+
 declare namespace browser.tabs {
   interface TabChangeInfo {
     attention?: boolean;

--- a/src/ui/common_components/ActivityTable.tsx
+++ b/src/ui/common_components/ActivityTable.tsx
@@ -131,7 +131,7 @@ const restoreCookies = async (
   log: ActivityLog,
   onRemoveActivity: ActivityAction,
 ) => {
-  const debug = getSetting(state, 'debugMode') as boolean;
+  const debug = getSetting(state, `${SettingID.DEBUG_MODE}`) as boolean;
   const cleanReasonObjsArrays = Object.values(log.storeIds);
   const promiseArr = [];
   cadLog(
@@ -209,7 +209,7 @@ const restoreCookies = async (
     await Promise.all(promiseArr).catch((e) => {
       throwErrorNotification(
         e,
-        getSetting(state, 'notificationOnScreen') as number,
+        getSetting(state, `${SettingID.NOTIFY_DURATION}`) as number,
       );
       cadLog(
         {
@@ -339,7 +339,10 @@ const ActivityTable: React.FunctionComponent<ActivityTableProps> = (props) => {
                   return (
                     <div key={`${storeId}-${log.dateTime}`}>
                       {(storeIdEntries.length > 1 ||
-                        getSetting(state, 'contextualIdentities')) && (
+                        getSetting(
+                          state,
+                          `${SettingID.CONTEXTUAL_IDENTITIES}`,
+                        )) && (
                         <h6>
                           {cache[storeId] !== undefined
                             ? `${cache[storeId]} `

--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -547,7 +547,10 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
 
 const mapStateToProps = (state: State) => {
   return {
-    contextualIdentities: getSetting(state, 'contextualIdentities') as boolean,
+    contextualIdentities: getSetting(
+      state,
+      `${SettingID.CONTEXTUAL_IDENTITIES}`,
+    ) as boolean,
     state,
   };
 };

--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -68,13 +68,16 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
 
   public async componentDidMount() {
     document.documentElement.style.fontSize = `${
-      (this.props.state.settings.sizePopup.value as number) || 16
+      (this.props.state.settings[`${SettingID.SIZE_POPUP}`].value as number) ||
+      16
     }px`;
     if (isChrome(this.props.state.cache)) {
       // Chrome requires min width otherwise the layout is messed up
       document.documentElement.style.minWidth = `${
         430 +
-        (((this.props.state.settings.sizePopup.value as number) || 16) - 10) *
+        (((this.props.state.settings[`${SettingID.SIZE_POPUP}`]
+          .value as number) || 16) -
+          10) *
           35
       }px`;
     }
@@ -252,20 +255,24 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
         >
           <IconButton
             iconName="power-off"
-            className={settings.activeMode.value ? 'btn-success' : 'btn-danger'}
+            className={
+              settings[`${SettingID.ACTIVE_MODE}`].value
+                ? 'btn-success'
+                : 'btn-danger'
+            }
             onClick={() =>
               onUpdateSetting({
-                ...settings.activeMode,
-                value: !settings.activeMode.value,
+                ...settings[`${SettingID.ACTIVE_MODE}`],
+                value: !settings[`${SettingID.ACTIVE_MODE}`].value,
               })
             }
             title={
-              settings.activeMode.value
+              settings[`${SettingID.ACTIVE_MODE}`].value
                 ? browser.i18n.getMessage('disableAutoDeleteText')
                 : browser.i18n.getMessage('enableAutoDeleteText')
             }
             text={
-              settings.activeMode.value
+              settings[`${SettingID.ACTIVE_MODE}`].value
                 ? browser.i18n.getMessage('autoDeleteEnabledText')
                 : browser.i18n.getMessage('autoDeleteDisabledText')
             }
@@ -273,24 +280,22 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
 
           <IconButton
             iconName={
-              settings.showNotificationAfterCleanup.value
-                ? 'bell'
-                : 'bell-slash'
+              settings[`${SettingID.NOTIFY_AUTO}`].value ? 'bell' : 'bell-slash'
             }
             className={
-              settings.showNotificationAfterCleanup.value
+              settings[`${SettingID.NOTIFY_AUTO}`].value
                 ? 'btn-success'
                 : 'btn-danger'
             }
             onClick={() =>
               onUpdateSetting({
-                ...settings.showNotificationAfterCleanup,
-                value: !settings.showNotificationAfterCleanup.value,
+                ...settings[`${SettingID.NOTIFY_AUTO}`],
+                value: !settings[`${SettingID.NOTIFY_AUTO}`].value,
               })
             }
             title={browser.i18n.getMessage('toggleNotificationText')}
             text={
-              settings.showNotificationAfterCleanup.value
+              settings[`${SettingID.NOTIFY_AUTO}`].value
                 ? browser.i18n.getMessage('notificationEnabledText')
                 : browser.i18n.getMessage('notificationDisabledText')
             }
@@ -549,7 +554,7 @@ const mapStateToProps = (state: State) => {
   return {
     contextualIdentities: getSetting(
       state,
-      `${SettingID.CONTEXTUAL_IDENTITIES}`,
+      SettingID.CONTEXTUAL_IDENTITIES,
     ) as boolean,
     state,
   };

--- a/src/ui/settings/App.tsx
+++ b/src/ui/settings/App.tsx
@@ -85,7 +85,7 @@ class App extends React.Component<OwnProps> {
 const mapStateToProps = (state: State) => {
   const { settings } = state;
   return {
-    sizeSetting: (settings.sizeSetting.value as number) || 16,
+    sizeSetting: (settings[`${SettingID.SIZE_SETTING}`].value as number) || 16,
   };
 };
 

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -3,7 +3,9 @@
     {
       "version": "3.6.0",
       "notes": [
-        "Fixed:  Duplication of domains in siteData Notifications."
+        "Added:  Implementation of FireFox Containers/Contextual Identities.  This allows CAD to monitor when changes to containers info have been made, and remove the CAD list matching that removed container ID.",
+        "Fixed:  Duplication of domains in siteData Notifications.",
+        "Chore:  Backend Code Optimizations."
       ]
     },
     {

--- a/src/ui/settings/components/Expressions.tsx
+++ b/src/ui/settings/components/Expressions.tsx
@@ -527,8 +527,11 @@ const mapStateToProps = (state: State) => {
   const { cache, lists } = state;
   return {
     bName: cache.browserDetect || (browserDetect() as browserName),
-    contextualIdentities: getSetting(state, 'contextualIdentities') as boolean,
-    debug: getSetting(state, 'debugMode') as boolean,
+    contextualIdentities: getSetting(
+      state,
+      `${SettingID.CONTEXTUAL_IDENTITIES}`,
+    ) as boolean,
+    debug: getSetting(state, `${SettingID.DEBUG_MODE}`) as boolean,
     lists,
   };
 };

--- a/src/ui/settings/components/Expressions.tsx
+++ b/src/ui/settings/components/Expressions.tsx
@@ -529,7 +529,7 @@ const mapStateToProps = (state: State) => {
     bName: cache.browserDetect || (browserDetect() as browserName),
     contextualIdentities: getSetting(
       state,
-      `${SettingID.CONTEXTUAL_IDENTITIES}`,
+      SettingID.CONTEXTUAL_IDENTITIES,
     ) as boolean,
     debug: getSetting(state, `${SettingID.DEBUG_MODE}`) as boolean,
     lists,

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -288,7 +288,7 @@ class Settings extends React.Component<SettingProps> {
             <CheckboxSetting
               text={browser.i18n.getMessage('activeModeText')}
               inline={true}
-              settingObject={settings.activeMode}
+              settingObject={settings[`${SettingID.ACTIVE_MODE}`]}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
             <SettingsTooltip hrefURL={'#enable-automatic-cleaning'} />
@@ -303,12 +303,12 @@ class Settings extends React.Component<SettingProps> {
                 const eValue = Number.parseInt(e.target.value, 10);
                 if (!Number.isNaN(eValue) && eValue >= 1 && eValue <= 2147483) {
                   onUpdateSetting({
-                    name: settings.delayBeforeClean.name,
+                    name: `${SettingID.CLEAN_DELAY}`,
                     value: eValue,
                   });
                 }
               }}
-              value={settings.delayBeforeClean.value as number}
+              value={settings[`${SettingID.CLEAN_DELAY}`].value as number}
               min="1"
               max="2147483"
               size={10}
@@ -322,7 +322,7 @@ class Settings extends React.Component<SettingProps> {
           <div className="form-group">
             <CheckboxSetting
               text={browser.i18n.getMessage('cleanDiscardedText')}
-              settingObject={settings.discardedCleanup}
+              settingObject={settings[`${SettingID.CLEAN_DISCARDED}`]}
               inline={true}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
@@ -331,7 +331,7 @@ class Settings extends React.Component<SettingProps> {
           <div className="form-group">
             <CheckboxSetting
               text={browser.i18n.getMessage('cleanupDomainChangeText')}
-              settingObject={settings.domainChangeCleanup}
+              settingObject={settings[`${SettingID.CLEAN_DOMAIN_CHANGE}`]}
               inline={true}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
@@ -339,8 +339,8 @@ class Settings extends React.Component<SettingProps> {
           </div>
           <div className="form-group">
             <CheckboxSetting
-              text={browser.i18n.getMessage('enableGreyListCleanup')}
-              settingObject={settings.enableGreyListCleanup}
+              text={browser.i18n.getMessage(`${SettingID.ENABLE_GREYLIST}`)}
+              settingObject={settings[`${SettingID.ENABLE_GREYLIST}`]}
               inline={true}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
@@ -351,7 +351,7 @@ class Settings extends React.Component<SettingProps> {
           <div className="form-group">
             <CheckboxSetting
               text={browser.i18n.getMessage('cookieCleanUpOnStartText')}
-              settingObject={settings.cleanCookiesFromOpenTabsOnStartup}
+              settingObject={settings[`${SettingID.CLEAN_OPEN_TABS_STARTUP}`]}
               inline={true}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
@@ -361,7 +361,7 @@ class Settings extends React.Component<SettingProps> {
           </div>
           <div className="form-group">
             <CheckboxSetting
-              settingObject={settings.cleanExpiredCookies}
+              settingObject={settings[`${SettingID.CLEAN_EXPIRED}`]}
               inline={true}
               text={browser.i18n.getMessage('cleanExpiredCookiesText')}
               updateSetting={(payload) => onUpdateSetting(payload)}
@@ -393,7 +393,7 @@ class Settings extends React.Component<SettingProps> {
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('cacheCleanupText')}
-                  settingObject={settings.cacheCleanup}
+                  settingObject={settings[`${SettingID.CLEANUP_CACHE}`]}
                   inline={true}
                   updateSetting={(payload) => onUpdateSetting(payload)}
                 />
@@ -407,7 +407,7 @@ class Settings extends React.Component<SettingProps> {
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('indexedDBCleanupText')}
-                  settingObject={settings.indexedDBCleanup}
+                  settingObject={settings[`${SettingID.CLEANUP_INDEXEDDB}`]}
                   inline={true}
                   updateSetting={(payload) => onUpdateSetting(payload)}
                 />
@@ -421,7 +421,7 @@ class Settings extends React.Component<SettingProps> {
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('localStorageCleanupText')}
-                  settingObject={settings.localStorageCleanup}
+                  settingObject={settings[`${SettingID.CLEANUP_LOCALSTORAGE}`]}
                   inline={true}
                   updateSetting={(payload) => onUpdateSetting(payload)}
                 />
@@ -435,7 +435,7 @@ class Settings extends React.Component<SettingProps> {
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('pluginDataCleanupText')}
-                  settingObject={settings.pluginDataCleanup}
+                  settingObject={settings[`${SettingID.CLEANUP_PLUGIN_DATA}`]}
                   inline={true}
                   updateSetting={(payload) => onUpdateSetting(payload)}
                 />
@@ -449,7 +449,9 @@ class Settings extends React.Component<SettingProps> {
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('serviceWorkersCleanupText')}
-                  settingObject={settings.serviceWorkersCleanup}
+                  settingObject={
+                    settings[`${SettingID.CLEANUP_SERVICE_WORKERS}`]
+                  }
                   inline={true}
                   updateSetting={(payload) => onUpdateSetting(payload)}
                 />
@@ -472,7 +474,7 @@ class Settings extends React.Component<SettingProps> {
                 text={browser.i18n.getMessage(
                   'contextualIdentitiesEnabledText',
                 )}
-                settingObject={settings.contextualIdentities}
+                settingObject={settings[`${SettingID.CONTEXTUAL_IDENTITIES}`]}
                 inline={true}
                 updateSetting={(payload) => onUpdateSetting(payload)}
               />
@@ -486,7 +488,7 @@ class Settings extends React.Component<SettingProps> {
           <div className="form-group">
             <CheckboxSetting
               text={browser.i18n.getMessage('enableCleanupLogText')}
-              settingObject={settings.statLogging}
+              settingObject={settings[`${SettingID.STAT_LOGGING}`]}
               inline={true}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
@@ -501,7 +503,7 @@ class Settings extends React.Component<SettingProps> {
             <div className="form-group">
               <CheckboxSetting
                 text={browser.i18n.getMessage('showNumberOfCookiesInIconText')}
-                settingObject={settings.showNumOfCookiesInIcon}
+                settingObject={settings[`${SettingID.NUM_COOKIES_ICON}`]}
                 inline={true}
                 updateSetting={(payload) => onUpdateSetting(payload)}
               />
@@ -514,8 +516,10 @@ class Settings extends React.Component<SettingProps> {
             settings.showNumOfCookiesInIcon.value === true && (
               <div className="form-group">
                 <CheckboxSetting
-                  text={browser.i18n.getMessage('keepDefaultIcon')}
-                  settingObject={settings.keepDefaultIcon}
+                  text={browser.i18n.getMessage(
+                    `${SettingID.KEEP_DEFAULT_ICON}`,
+                  )}
+                  settingObject={settings[`${SettingID.KEEP_DEFAULT_ICON}`]}
                   inline={true}
                   updateSetting={(payload) => onUpdateSetting(payload)}
                 />
@@ -527,7 +531,7 @@ class Settings extends React.Component<SettingProps> {
           <div className="form-group">
             <CheckboxSetting
               text={browser.i18n.getMessage('notifyCookieCleanUpText')}
-              settingObject={settings.showNotificationAfterCleanup}
+              settingObject={settings[SettingID.NOTIFY_AUTO]}
               inline={true}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
@@ -538,7 +542,7 @@ class Settings extends React.Component<SettingProps> {
           <div className="form-group">
             <CheckboxSetting
               inline={true}
-              settingObject={settings.manualNotifications}
+              settingObject={settings[`${SettingID.NOTIFY_MANUAL}`]}
               text={browser.i18n.getMessage('manualNotificationsText')}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
@@ -550,7 +554,7 @@ class Settings extends React.Component<SettingProps> {
             <SelectInput
               numSize={9}
               numStart={1}
-              settingObject={settings.notificationOnScreen}
+              settingObject={settings[`${SettingID.NOTIFY_DURATION}`]}
               text={`${browser.i18n.getMessage(
                 'secondsText',
               )} ${browser.i18n.getMessage('notifyCookieCleanupDelayText')}`}
@@ -562,8 +566,8 @@ class Settings extends React.Component<SettingProps> {
           </div>
           <div className="form-group">
             <CheckboxSetting
-              text={browser.i18n.getMessage('enableNewVersionPopup')}
-              settingObject={settings.enableNewVersionPopup}
+              text={browser.i18n.getMessage(`${SettingID.ENABLE_NEW_POPUP}`)}
+              settingObject={settings[`${SettingID.ENABLE_NEW_POPUP}`]}
               inline={true}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
@@ -575,11 +579,9 @@ class Settings extends React.Component<SettingProps> {
             <SelectInput
               numSize={14}
               numStart={10}
-              settingObject={settings.sizePopup}
+              settingObject={settings[`${SettingID.SIZE_POPUP}`]}
               text={browser.i18n.getMessage('sizePopupText')}
-              updateSetting={(payload) => {
-                onUpdateSetting(payload);
-              }}
+              updateSetting={(payload) => onUpdateSetting(payload)}
             />
             <SettingsTooltip hrefURL={'#size-of-popup'} />
           </div>
@@ -587,7 +589,7 @@ class Settings extends React.Component<SettingProps> {
             <SelectInput
               numSize={14}
               numStart={10}
-              settingObject={settings.sizeSetting}
+              settingObject={settings[`${SettingID.SIZE_SETTING}`]}
               text={browser.i18n.getMessage('sizeSettingText')}
               updateSetting={(payload) => {
                 onUpdateSetting(payload);
@@ -599,7 +601,7 @@ class Settings extends React.Component<SettingProps> {
             <div className="form-group">
               <CheckboxSetting
                 text={browser.i18n.getMessage('enableContextMenus')}
-                settingObject={settings.contextMenus}
+                settingObject={settings[`${SettingID.CONTEXT_MENUS}`]}
                 inline={true}
                 updateSetting={(payload) => onUpdateSetting(payload)}
               />
@@ -609,8 +611,8 @@ class Settings extends React.Component<SettingProps> {
           {(isFirefoxNotAndroid(cache) || isChrome(cache)) && (
             <div className="form-group">
               <CheckboxSetting
-                text={browser.i18n.getMessage('debugMode')}
-                settingObject={settings.debugMode}
+                text={browser.i18n.getMessage(`${SettingID.DEBUG_MODE}`)}
+                settingObject={settings[`${SettingID.DEBUG_MODE}`]}
                 inline={true}
                 updateSetting={(payload) => onUpdateSetting(payload)}
               />

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -67,7 +67,7 @@ class Settings extends React.Component<SettingProps> {
   // Import Settings
   public importCoreSettings(importFile: File) {
     const { settings } = this.props;
-    const debug = settings.debugMode.value as boolean;
+    const debug = settings[`${SettingID.DEBUG_MODE}`].value as boolean;
     cadLog(
       {
         msg: 'Import Core Settings received file for parsing.',
@@ -194,7 +194,7 @@ class Settings extends React.Component<SettingProps> {
         type: 'info',
         x: r,
       },
-      settings.debugMode.value as boolean,
+      settings[`${SettingID.DEBUG_MODE}`].value as boolean,
     );
     this.setState({
       error: '',
@@ -326,7 +326,9 @@ class Settings extends React.Component<SettingProps> {
               inline={true}
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
-            <SettingsTooltip hrefURL={'#enable-cleanup-for-discardedunloaded-tabs'} />
+            <SettingsTooltip
+              hrefURL={'#enable-cleanup-for-discardedunloaded-tabs'}
+            />
           </div>
           <div className="form-group">
             <CheckboxSetting
@@ -493,7 +495,7 @@ class Settings extends React.Component<SettingProps> {
               updateSetting={(payload) => onUpdateSetting(payload)}
             />
             <SettingsTooltip hrefURL={'#enable-cleanup-log-and-counter'} />
-            {settings.statLogging.value && (
+            {settings[`${SettingID.STAT_LOGGING}`].value && (
               <div className="alert alert-warning">
                 {browser.i18n.getMessage('noPrivateLogging')}
               </div>
@@ -513,7 +515,7 @@ class Settings extends React.Component<SettingProps> {
             </div>
           )}
           {(!isFirefox(cache) || isFirefoxNotAndroid(cache)) &&
-            settings.showNumOfCookiesInIcon.value === true && (
+            settings[`${SettingID.NUM_COOKIES_ICON}`].value === true && (
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage(
@@ -617,7 +619,7 @@ class Settings extends React.Component<SettingProps> {
                 updateSetting={(payload) => onUpdateSetting(payload)}
               />
               <SettingsTooltip hrefURL={'#debug-mode'} />
-              {settings.debugMode.value && (
+              {settings[`${SettingID.DEBUG_MODE}`].value && (
                 <div className="alert alert-info">
                   <p>{browser.i18n.getMessage('openDebugMode')}</p>
                   <pre>


### PR DESCRIPTION
This implements the ContextualIdentityService, updating and removing container lists as needed (Firefox only).

Added eventListenerActions, a common function to check if event listeners are added/removed and do so accordingly.

This also adds a generic string enumeration for SettingID to be more easily used everywhere else (pre-compile that is).

Also added CookieEvents Tests.

Sep 18th added SettingService

Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>