### PR TITLE
Widen delayBeforeClean number input field in settings

### DIFF
--- a/extension/settings/settings.css
+++ b/extension/settings/settings.css
@@ -21,6 +21,10 @@ input[type='number'] {
   width: 5em;
 }
 
+input[type='number']#delayBeforeClean {
+  width: 7em;
+}
+
 label:hover {
   background-color: #d3d3d3;
   cursor: pointer;


### PR DESCRIPTION
The `delayBeforeClean` input field in settings was narrow enough that it could potentially hide the rightmost digits of very large numbers. For example, if you have it set to auto-clean every week (604800 seconds), the two rightmost digits are cut off:

![Markup on 2020-08-06 at 16:13:39](https://user-images.githubusercontent.com/5512652/89578855-d1d1ab00-d800-11ea-8a3a-f52c7ccfd5c5.png)

This minor CSS change widens the field to accommodate the maximum number of digits in the value: 7. Using the maximum value of 2147483 as an example:

![Markup on 2020-08-06 at 16:22:07](https://user-images.githubusercontent.com/5512652/89579025-0f363880-d801-11ea-905c-c39adfe4e774.png)

Also looks good in Firefox:

![Markup on 2020-08-06 at 16:25:18](https://user-images.githubusercontent.com/5512652/89579252-748a2980-d801-11ea-9506-3264c0d95577.png)

