### PR TITLE
Fix FirstPartyIsolate and use_case settings.

### DIFF
--- a/.github/workflows/codecov_alt.sh
+++ b/.github/workflows/codecov_alt.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "$PR_NUM"
+if [ -z "$PR_NUM" ]; then
+  bash <(curl -s https://codecov.io/bash) -f ./coverage/* -Z
+  exit $?
+else
+  bash <(curl -s https://codecov.io/bash) -f ./coverage/* -P $PR_NUM -Z
+  exit $?
+fi

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -245,7 +245,7 @@ describe('CleanupService', () => {
     });
 
     it('should be called 5 times for cookies.remove', async () => {
-      await cleanCookies(initialState, removeCookies, false);
+      await cleanCookies(initialState, removeCookies);
       expect(global.browser.cookies.remove).toBeCalledTimes(5);
     });
 
@@ -254,9 +254,7 @@ describe('CleanupService', () => {
         .calledWith(expect.any(Object))
         .mockResolvedValueOnce(true as never)
         .mockRejectedValueOnce(new Error('test') as never);
-      await expect(
-        cleanCookies(initialState, removeCookies, false),
-      ).rejects.toThrow();
+      await expect(cleanCookies(initialState, removeCookies)).rejects.toThrow();
       expect(global.browser.cookies.remove.mock.results[2].value).toEqual(
         undefined,
       );

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -1022,7 +1022,7 @@ describe('Library Functions', () => {
   });
 
   describe('returnOptionalCookieAPIAttributes()', () => {
-    it('should return an object with an undefined firstPartyDomain when firstPartyIsolate is true and firstPartyDomain was not already defined.', () => {
+    it('should return an object with an undefined firstPartyDomain if browser was Firefox and firstPartyDomain was not already defined.', () => {
       const state = {
         ...initialState,
         cache: {
@@ -1036,7 +1036,6 @@ describe('Library Functions', () => {
       const results = returnOptionalCookieAPIAttributes(
         state,
         cookieAPIAttributes,
-        true,
       );
       expect(results).toEqual(
         expect.objectContaining({
@@ -1046,7 +1045,7 @@ describe('Library Functions', () => {
       );
     });
 
-    it('should return an object the same object with a firstPartyDomain if firstPartyIsolate was true', () => {
+    it('should return an object the same object with a firstPartyDomain if browser was firefox and firstPartyDomain was given', () => {
       const state = {
         ...initialState,
         cache: {
@@ -1061,7 +1060,6 @@ describe('Library Functions', () => {
       const results = returnOptionalCookieAPIAttributes(
         state,
         cookieAPIAttributes,
-        true,
       );
       expect(results).toEqual(
         expect.objectContaining({
@@ -1071,30 +1069,7 @@ describe('Library Functions', () => {
       );
     });
 
-    it('should return an object with no firstPartyDomain if firstPartyIsolate was false', () => {
-      const state = {
-        ...initialState,
-        cache: {
-          browserDetect: browserName.Firefox,
-        },
-      };
-      const cookieAPIAttributes = {
-        ...mockCookie,
-        firstPartyDomain: '',
-      };
-      const results = returnOptionalCookieAPIAttributes(
-        state,
-        cookieAPIAttributes,
-        false,
-      );
-      expect(results).toEqual(
-        expect.not.objectContaining({
-          firstPartyDomain: '',
-        }),
-      );
-    });
-
-    it('should return an object with no firstPartyDomain (Browser other than FF) (firstPartyIsolate is false)', () => {
+    it('should return an object with no firstPartyDomain (Browser other than FF)', () => {
       const state = {
         ...initialState,
         cache: {
@@ -1108,13 +1083,8 @@ describe('Library Functions', () => {
       const results = returnOptionalCookieAPIAttributes(
         state,
         cookieAPIAttributes,
-        false,
       );
-      expect(results).toEqual(
-        expect.not.objectContaining({
-          firstPartyDomain: '',
-        }),
-      );
+      expect(results).not.toHaveProperty('firstPartyDomain');
     });
   });
 

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -18,6 +18,7 @@ import {
   convertVersionToNumber,
   createPartialTabInfo,
   extractMainDomain,
+  getAllCookiesForDomain,
   getContainerExpressionDefault,
   getHostname,
   getSetting,
@@ -367,6 +368,196 @@ describe('Library Functions', () => {
 
     it('should return nothing on empty string', () => {
       expect(extractMainDomain('')).toEqual('');
+    });
+  });
+
+  describe('getAllCookiesForDomain()', () => {
+    beforeAll(() => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: expect.any(String), storeId: 'firefox-default' })
+        .mockResolvedValue([] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({
+          domain: expect.any(String),
+          firstPartyDomain: expect.any(String),
+          storeId: 'firefox-default',
+        })
+        .mockResolvedValue([] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({ storeId: 'firefox-default' })
+        .mockResolvedValue([
+          testCookie,
+          { ...testCookie, domain: '', path: '/test/' },
+        ] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({ storeId: 'firefox-default', firstPartyDomain: undefined })
+        .mockResolvedValue([
+          testCookie,
+          { ...testCookie, domain: '', path: '/test/' },
+        ] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: '' })
+        .mockResolvedValue([] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: 'domain.com', storeId: 'firefox-default' })
+        .mockResolvedValue([testCookie] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({
+          domain: '10.1.1.1',
+          firstPartyDomain: '10.1.1.1',
+          storeId: 'firefox-default',
+        })
+        .mockResolvedValue([testCookie] as never);
+    });
+
+    const testCookie: browser.cookies.Cookie = {
+      domain: 'domain.com',
+      hostOnly: true,
+      httpOnly: true,
+      name: 'blah',
+      path: '/',
+      sameSite: 'no_restriction',
+      secure: true,
+      session: true,
+      storeId: 'firefox-default',
+      value: 'test value',
+    };
+
+    const sampleTab: browser.tabs.Tab = {
+      active: true,
+      cookieStoreId: 'firefox-default',
+      discarded: false,
+      hidden: false,
+      highlighted: false,
+      incognito: false,
+      index: 0,
+      isArticle: false,
+      isInReaderMode: false,
+      lastAccessed: 12345678,
+      pinned: false,
+      selected: true,
+      url: 'https://www.example.com',
+      windowId: 1,
+    };
+
+    const chromeState: State = {
+      ...initialState,
+      cache: {
+        browserDetect: browserName.Chrome,
+      },
+    };
+
+    const firefoxState: State = {
+      ...initialState,
+      cache: {
+        browserDetect: browserName.Firefox,
+      },
+    };
+
+    it('should do nothing if url is an internal page', async () => {
+      const result = await getAllCookiesForDomain(chromeState, {
+        ...sampleTab,
+        url: 'about:home',
+      });
+      const result2 = await getAllCookiesForDomain(chromeState, {
+        ...sampleTab,
+        url: 'chrome:newtab',
+      });
+      expect(result).toBeUndefined();
+      expect(result2).toBeUndefined();
+    });
+
+    it('should do nothing if url is empty string', async () => {
+      const result = await getAllCookiesForDomain(chromeState, {
+        ...sampleTab,
+        url: '',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should do nothing if url is undefined', async () => {
+      const result = await getAllCookiesForDomain(chromeState, {
+        ...sampleTab,
+        url: undefined,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should do nothing if url is not valid', async () => {
+      const result = await getAllCookiesForDomain(firefoxState, {
+        ...sampleTab,
+        url: 'bad',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    // Test in Chrome, though both FF and Chrome should return same thing.
+    it('should work on local files', async () => {
+      const result = await getAllCookiesForDomain(chromeState, {
+        ...sampleTab,
+        url: 'file:///test/file.html',
+      });
+      expect(result).toStrictEqual(
+        expect.arrayContaining([{ ...testCookie, domain: '', path: '/test/' }]),
+      );
+    });
+
+    it('should fetch additional FPI Cookies (use_site enabled) as needed', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({
+          domain: 'domain.com',
+          firstPartyDomain: 'domain.com',
+          storeId: 'firefox-default',
+        })
+        .mockResolvedValue([{ ...testCookie, name: 'old FPI' }] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({
+          domain: 'domain.com',
+          firstPartyDomain: '(https,domain.com)',
+          storeId: 'firefox-default',
+        })
+        .mockResolvedValue([{ ...testCookie, name: 'FPI_use_case' }] as never);
+      const result = await getAllCookiesForDomain(firefoxState, {
+        ...sampleTab,
+        url: 'https://domain.com',
+      });
+      expect(result).toStrictEqual([
+        { ...testCookie, name: 'old FPI' },
+        { ...testCookie, name: 'FPI_use_case' },
+      ]);
+    });
+    it('should fetch additional FPI Cookies (use_site enabled) with a port in URL as needed', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({
+          domain: '10.1.1.1',
+          firstPartyDomain: '10.1.1.1',
+          storeId: 'firefox-default',
+        })
+        .mockResolvedValue([testCookie] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({
+          domain: '10.1.1.1',
+          firstPartyDomain: '(https,10.1.1.1)',
+          storeId: 'firefox-default',
+        })
+        .mockResolvedValue([] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({
+          domain: '10.1.1.1',
+          firstPartyDomain: '(https,10.1.1.1,8080)',
+          storeId: 'firefox-default',
+        })
+        .mockResolvedValue([
+          { ...testCookie, name: 'FPI_usecase_port' },
+        ] as never);
+      const result = await getAllCookiesForDomain(firefoxState, {
+        ...sampleTab,
+        url: 'https://10.1.1.1:8080',
+      });
+      expect(result).toStrictEqual([
+        testCookie,
+        { ...testCookie, name: 'FPI_usecase_port' },
+      ]);
     });
   });
 

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -120,12 +120,6 @@ describe('TabEvents', () => {
   describe('getAllCookieActions', () => {
     beforeAll(() => {
       when(global.browser.cookies.getAll)
-        .calledWith({ storeId: 'firefox-default' })
-        .mockResolvedValue([
-          testCookie,
-          { ...testCookie, domain: '', path: '/test/' },
-        ] as never);
-      when(global.browser.cookies.getAll)
         .calledWith({ domain: '' })
         .mockResolvedValue([] as never);
       when(global.browser.cookies.getAll)
@@ -148,12 +142,12 @@ describe('TabEvents', () => {
 
     it('should do nothing if url is undefined', async () => {
       await TabEvents.getAllCookieActions({ ...sampleTab, url: undefined });
-      expect(global.browser.cookies.getAll).not.toHaveBeenCalled();
+      expect(spyLib.getAllCookiesForDomain).not.toHaveBeenCalled();
     });
 
     it('should do nothing if url is empty string', async () => {
       await TabEvents.getAllCookieActions({ ...sampleTab, url: '' });
-      expect(global.browser.cookies.getAll).not.toHaveBeenCalled();
+      expect(spyLib.getAllCookiesForDomain).not.toHaveBeenCalled();
     });
 
     it('should do nothing if url is an internal page', async () => {
@@ -162,20 +156,12 @@ describe('TabEvents', () => {
         ...sampleTab,
         url: 'chrome:newtab',
       });
-      expect(global.browser.cookies.getAll).not.toHaveBeenCalled();
+      expect(spyLib.getAllCookiesForDomain).not.toHaveBeenCalled();
     });
 
     it('should do nothing if url is not valid', async () => {
       await TabEvents.getAllCookieActions({ ...sampleTab, url: 'bad' });
       expect(global.browser.cookies.getAll).not.toHaveBeenCalled();
-    });
-
-    it('should work on local files', async () => {
-      await TabEvents.getAllCookieActions({
-        ...sampleTab,
-        url: 'file:///test/file.html',
-      });
-      expect(spyBrowserActions.checkIfProtected.mock.calls[0][2]).toBe(1);
     });
 
     it('should work on regular domains', async () => {
@@ -210,7 +196,7 @@ describe('TabEvents', () => {
       expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
     });
 
-    it('should create a cookie if clean localstorage was enabled and no cookie was found', async () => {
+    it('should create a cookie if clean localStorage was enabled and no cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -246,7 +232,7 @@ describe('TabEvents', () => {
       expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
     });
 
-    it('should filter out CAD LocalStorage cookie from total cookie count', async () => {
+    it('should filter out CAD browsingDataCleanup cookie from total cookie count', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -291,6 +291,7 @@ export const cleanCookies = async (
       name: cookieProperties.name,
       url: cookieProperties.preparedCookieDomain,
     };
+    // url: "http://domain.com" + cookies[i].path
     cadLog(
       {
         msg:
@@ -299,7 +300,6 @@ export const cleanCookies = async (
       },
       getSetting(state, 'debugMode') as boolean,
     );
-    // url: "http://domain.com" + cookies[i].path
     const promise = browser.cookies.remove(cookieRemove);
     promiseArr.push(promise);
   });

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -20,7 +20,6 @@ import {
   isAWebpage,
   isChrome,
   isFirefoxNotAndroid,
-  isFirstPartyIsolate,
   prepareCleanupDomains,
   prepareCookieDomain,
   returnMatchedExpressionObject,
@@ -279,19 +278,14 @@ export const isSafeToClean = (
 export const cleanCookies = async (
   state: State,
   markedForDeletion: CleanReasonObject[],
-  firstPartyIsolate: boolean,
 ): Promise<void> => {
   const promiseArr: Promise<browser.cookies.Cookie | null>[] = [];
   markedForDeletion.forEach((obj) => {
     const cookieProperties = obj.cookie;
-    const cookieAPIProperties = returnOptionalCookieAPIAttributes(
-      state,
-      {
-        firstPartyDomain: cookieProperties.firstPartyDomain,
-        storeId: cookieProperties.storeId,
-      },
-      firstPartyIsolate,
-    );
+    const cookieAPIProperties = returnOptionalCookieAPIAttributes(state, {
+      firstPartyDomain: cookieProperties.firstPartyDomain,
+      storeId: cookieProperties.storeId,
+    });
     const cookieRemove = {
       ...cookieAPIProperties,
       name: cookieProperties.name,
@@ -320,16 +314,11 @@ export const clearCookiesForThisDomain = async (
   tab: browser.tabs.Tab,
 ): Promise<boolean> => {
   const hostname = getHostname(tab.url);
-  const firstPartyIsolate = await isFirstPartyIsolate();
   const getCookies = await browser.cookies.getAll(
-    returnOptionalCookieAPIAttributes(
-      state,
-      {
-        domain: hostname,
-        storeId: tab.cookieStoreId,
-      },
-      firstPartyIsolate,
-    ),
+    returnOptionalCookieAPIAttributes(state, {
+      domain: hostname,
+      storeId: tab.cookieStoreId,
+    }),
   );
   // Filter out our own CAD cookie that cleans up other Browsing Data
   const cookies = getCookies.filter((c) => c.name !== CADCOOKIENAME);
@@ -338,16 +327,12 @@ export const clearCookiesForThisDomain = async (
     let cookieDeletedCount = 0;
     for (const cookie of cookies) {
       const r = await browser.cookies.remove(
-        returnOptionalCookieAPIAttributes(
-          state,
-          {
-            firstPartyDomain: cookie.firstPartyDomain,
-            name: cookie.name,
-            storeId: cookie.storeId,
-            url: prepareCookieDomain(cookie),
-          },
-          firstPartyIsolate,
-        ) as {
+        returnOptionalCookieAPIAttributes(state, {
+          firstPartyDomain: cookie.firstPartyDomain,
+          name: cookie.name,
+          storeId: cookie.storeId,
+          url: prepareCookieDomain(cookie),
+        }) as {
           // This explicit type is required as cookies.remove requires these two
           // parameters, but url is not defined in cookies.Cookie as it is made
           // up of cookie.domain + cookie.path, and neither required parameters
@@ -794,7 +779,6 @@ export const cleanCookiesOperation = async (
     ...cleanupProperties,
     openTabDomains,
   };
-  const firstPartyIsolate = await isFirstPartyIsolate();
 
   const cookieStoreIds = new Set<string>();
 
@@ -846,13 +830,9 @@ export const cleanCookiesOperation = async (
     let cookies: browser.cookies.Cookie[] = [];
     try {
       cookies = await browser.cookies.getAll(
-        returnOptionalCookieAPIAttributes(
-          state,
-          {
-            storeId: id,
-          },
-          firstPartyIsolate,
-        ),
+        returnOptionalCookieAPIAttributes(state, {
+          storeId: id,
+        }),
       );
     } catch (e) {
       cadLog(
@@ -930,7 +910,7 @@ export const cleanCookiesOperation = async (
     }
 
     try {
-      await cleanCookies(state, markedForDeletion, firstPartyIsolate);
+      await cleanCookies(state, markedForDeletion);
     } catch (e) {
       cadLog(
         {

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -160,7 +160,7 @@ export const getAllCookiesForDomain = async (
   state: State,
   tab: browser.tabs.Tab,
 ): Promise<browser.cookies.Cookie[] | undefined> => {
-  if (!tab.url) return;
+  if (!tab.url || tab.url === '') return;
   if (tab.url.startsWith('about:') || tab.url.startsWith('chrome:')) return;
   const debug = getSetting(state, 'debugMode') as boolean;
   const partialTabInfo = createPartialTabInfo(tab);

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -465,12 +465,12 @@ export const returnOptionalCookieAPIAttributes = (
   cookieAPIAttributes: Partial<CookiePropertiesCleanup> & {
     [x: string]: any;
   },
-  firstPartyIsolate: boolean,
 ): Partial<CookiePropertiesCleanup> => {
   // Add optional firstPartyDomain attribute
+  // To fetch firstPartyIsolation cookies even if FPI is off,
+  // set firstPartyDomain to null.
   if (
     isFirefox(state.cache) &&
-    firstPartyIsolate &&
     !Object.prototype.hasOwnProperty.call(
       cookieAPIAttributes,
       'firstPartyDomain',
@@ -481,7 +481,8 @@ export const returnOptionalCookieAPIAttributes = (
       firstPartyDomain: undefined,
     };
   }
-  if (!(isFirefox(state.cache) && firstPartyIsolate)) {
+  // Only remove FPI Property if it is NOT firefox.
+  if (!isFirefox(state.cache)) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { firstPartyDomain, ...rest } = cookieAPIAttributes;
     return rest;

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -152,6 +152,134 @@ export const extractMainDomain = (domain: string): string => {
 };
 
 /**
+ * This fetches all (first party) cookies for a given tab domain
+ * @param state The webextension state
+ * @param tab The tab to fetch all (first party) cookies for.
+ */
+export const getAllCookiesForDomain = async (
+  state: State,
+  tab: browser.tabs.Tab,
+): Promise<browser.cookies.Cookie[] | undefined> => {
+  if (!tab.url) return;
+  if (tab.url.startsWith('about:') || tab.url.startsWith('chrome:')) return;
+  const debug = getSetting(state, 'debugMode') as boolean;
+  const partialTabInfo = createPartialTabInfo(tab);
+  const { cookieStoreId, url } = tab;
+  const hostname = getHostname(url);
+  if (hostname === '') {
+    cadLog(
+      {
+        msg: 'Libs.getAllCookiesForDomain:  hostname parsed empty for tab url.',
+        x: { partialTabInfo, hostname },
+      },
+      debug,
+    );
+    return;
+  }
+  let cookies: browser.cookies.Cookie[] = [];
+  const mainDomain = extractMainDomain(hostname);
+
+  if (hostname.startsWith('file:')) {
+    const allCookies = await browser.cookies.getAll(
+      returnOptionalCookieAPIAttributes(state, {
+        storeId: cookieStoreId,
+      }),
+    );
+    const regExp = new RegExp(hostname.slice(7)); // take out 'file://'
+    cadLog(
+      {
+        msg:
+          'Libs.getAllCookiesForDomain:  Local File Regex to rest on cookie.path',
+        x: { partialTabInfo, hostname, regExp: regExp.toString() },
+      },
+      debug,
+    );
+    cookies = allCookies.filter((c) => c.domain === '' && regExp.test(c.path));
+  } else {
+    cadLog(
+      {
+        msg: 'Libs.getAllCookiesForDomain:  browser.cookies.getAll for domain.',
+        x: {
+          partialTabInfo,
+          domain: hostname,
+          firstPartyDomain: mainDomain,
+        },
+      },
+      debug,
+    );
+    cookies = await browser.cookies.getAll(
+      returnOptionalCookieAPIAttributes(state, {
+        domain: hostname,
+        firstPartyDomain: mainDomain,
+        storeId: cookieStoreId,
+      }),
+    );
+  }
+  cadLog(
+    {
+      msg: 'Libs.getAllCookiesForDomain:  Filtered Cookie Count',
+      x: {
+        partialTabInfo,
+        tabURL: tab.url,
+        hostname,
+        cookieCount: cookies.length,
+      },
+    },
+    debug,
+  );
+
+  if (!isFirefox(state.cache)) return cookies;
+  // Firefox only - try to get additional firstParty Isolation cookies
+  // if firstparty.isolation.use_site was enabled, to which we don't know
+  const siteURL = new URL(url);
+  const proto = siteURL.protocol.replace(':', '');
+  // firstPartyDomain = (https,domain.com)
+  cadLog(
+    {
+      msg: 'Libs.getAllCookiesForDomain:  browser.cookies.getAll for domain.',
+      x: {
+        partialTabInfo,
+        domain: hostname,
+        firstPartyDomain: `(${proto},${mainDomain})`,
+      },
+    },
+    debug,
+  );
+  const cookies_fpi_usesite = await browser.cookies.getAll(
+    returnOptionalCookieAPIAttributes(state, {
+      domain: hostname,
+      firstPartyDomain: `(${proto},${mainDomain})`,
+      storeId: cookieStoreId,
+    }),
+  );
+  cookies_fpi_usesite.forEach((c) => cookies.push(c));
+  // firstPartyDomain = (https,domain.com,2048)
+  // Should only be used when domain is an IP, but just in case.
+  if (siteURL.port) {
+    cadLog(
+      {
+        msg: 'Libs.getAllCookiesForDomain:  browser.cookies.getAll for domain.',
+        x: {
+          partialTabInfo,
+          domain: hostname,
+          firstPartyDomain: `(${proto},${mainDomain},${siteURL.port})`,
+        },
+      },
+      debug,
+    );
+    const cookies_fpi_usesite_port = await browser.cookies.getAll(
+      returnOptionalCookieAPIAttributes(state, {
+        domain: hostname,
+        firstPartyDomain: `(${proto},${mainDomain},${siteURL.port})`,
+        storeId: cookieStoreId,
+      }),
+    );
+    cookies_fpi_usesite_port.forEach((c) => cookies.push(c));
+  }
+  return cookies;
+};
+
+/**
  * Returns the host name of the url.
  *   - https://en.wikipedia.org/wiki/Cat ==> en.wikipedia.org
  *

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -245,14 +245,14 @@ export const getAllCookiesForDomain = async (
     },
     debug,
   );
-  const cookies_fpi_usesite = await browser.cookies.getAll(
+  const cookiesFPIUseSite = await browser.cookies.getAll(
     returnOptionalCookieAPIAttributes(state, {
       domain: hostname,
       firstPartyDomain: `(${proto},${mainDomain})`,
       storeId: cookieStoreId,
     }),
   );
-  cookies_fpi_usesite.forEach((c) => cookies.push(c));
+  cookiesFPIUseSite.forEach((c) => cookies.push(c));
   // firstPartyDomain = (https,domain.com,2048)
   // Should only be used when domain is an IP, but just in case.
   if (siteURL.port) {
@@ -267,14 +267,14 @@ export const getAllCookiesForDomain = async (
       },
       debug,
     );
-    const cookies_fpi_usesite_port = await browser.cookies.getAll(
+    const cookiesFPIUseSitePort = await browser.cookies.getAll(
       returnOptionalCookieAPIAttributes(state, {
         domain: hostname,
         firstPartyDomain: `(${proto},${mainDomain},${siteURL.port})`,
         storeId: cookieStoreId,
       }),
     );
-    cookies_fpi_usesite_port.forEach((c) => cookies.push(c));
+    cookiesFPIUseSitePort.forEach((c) => cookies.push(c));
   }
   return cookies;
 };

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -25,7 +25,6 @@ import {
   getHostname,
   getSetting,
   isAWebpage,
-  isFirstPartyIsolate,
   returnOptionalCookieAPIAttributes,
 } from './Libs';
 import StoreUser from './StoreUser';
@@ -281,17 +280,12 @@ export default class TabEvents extends StoreUser {
       );
       return;
     }
-    const firstPartyIsolate = await isFirstPartyIsolate();
     let cookies: browser.cookies.Cookie[];
     if (hostname.startsWith('file:')) {
       const allCookies = await browser.cookies.getAll(
-        returnOptionalCookieAPIAttributes(
-          StoreUser.store.getState(),
-          {
-            storeId: tab.cookieStoreId,
-          },
-          firstPartyIsolate,
-        ),
+        returnOptionalCookieAPIAttributes(StoreUser.store.getState(), {
+          storeId: tab.cookieStoreId,
+        }),
       );
       const regExp = new RegExp(hostname.slice(7)); // take out file://
       cadLog(
@@ -319,15 +313,11 @@ export default class TabEvents extends StoreUser {
         debug,
       );
       cookies = await browser.cookies.getAll(
-        returnOptionalCookieAPIAttributes(
-          StoreUser.store.getState(),
-          {
-            domain: hostname,
-            firstPartyDomain: extractMainDomain(hostname),
-            storeId: tab.cookieStoreId,
-          },
-          firstPartyIsolate,
-        ),
+        returnOptionalCookieAPIAttributes(StoreUser.store.getState(), {
+          domain: hostname,
+          firstPartyDomain: extractMainDomain(hostname),
+          storeId: tab.cookieStoreId,
+        }),
       );
     }
     cadLog(
@@ -364,7 +354,6 @@ export default class TabEvents extends StoreUser {
           url: tab.url,
           value: CADCOOKIENAME,
         },
-        firstPartyIsolate,
       );
       await browser.cookies.set({ ...cookiesAttributes, url: tab.url });
       cadLog(

--- a/src/ui/common_components/ActivityTable.tsx
+++ b/src/ui/common_components/ActivityTable.tsx
@@ -17,7 +17,6 @@ import { removeActivity } from '../../redux/Actions';
 import {
   cadLog,
   getSetting,
-  isFirstPartyIsolate,
   returnOptionalCookieAPIAttributes,
   siteDataToBrowser,
   throwErrorNotification,
@@ -135,7 +134,6 @@ const restoreCookies = async (
   const debug = getSetting(state, 'debugMode') as boolean;
   const cleanReasonObjsArrays = Object.values(log.storeIds);
   const promiseArr = [];
-  const firstPartyIsolate = await isFirstPartyIsolate();
   cadLog(
     {
       msg: `ActivityTable.restoreCookies:  Restoring Cookies for triggered ActivityLog entry`,
@@ -189,13 +187,9 @@ const restoreCookies = async (
       // and url should already start with https://
       // Only modify cookie names starting with __Host- as it shouldn't have domain.
       const cookieProperties = {
-        ...returnOptionalCookieAPIAttributes(
-          state,
-          {
-            firstPartyDomain,
-          },
-          firstPartyIsolate,
-        ),
+        ...returnOptionalCookieAPIAttributes(state, {
+          firstPartyDomain,
+        }),
         domain: name.startsWith('__Host-') || hostOnly ? undefined : domain,
         expirationDate,
         httpOnly,

--- a/src/ui/common_components/ExpressionOptions.tsx
+++ b/src/ui/common_components/ExpressionOptions.tsx
@@ -19,7 +19,6 @@ import {
   isChrome,
   isFirefox,
   isFirefoxNotAndroid,
-  isFirstPartyIsolate,
   returnOptionalCookieAPIAttributes,
 } from '../../services/Libs';
 import { ReduxAction } from '../../typings/ReduxConstants';
@@ -83,18 +82,13 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
   public async getAllCookies() {
     const { expression } = this.props;
     const exp = expression.expression;
-    const firstPartyIsolate = await isFirstPartyIsolate();
     let cookies: browser.cookies.CookieProperties[];
     if (exp.startsWith('/') && exp.endsWith('/')) {
       // Treat expression as regular expression.  Get all cookies then regex domain.
       const allCookies = await browser.cookies.getAll(
-        returnOptionalCookieAPIAttributes(
-          this.props.state,
-          {
-            storeId: this.toPublicStoreId(expression.storeId),
-          },
-          firstPartyIsolate,
-        ),
+        returnOptionalCookieAPIAttributes(this.props.state, {
+          storeId: this.toPublicStoreId(expression.storeId),
+        }),
       );
       if (exp.slice(1).startsWith('file:')) {
         // Regex with Local Directories
@@ -108,13 +102,9 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
       }
     } else if (exp.startsWith('file:')) {
       const allCookies = await browser.cookies.getAll(
-        returnOptionalCookieAPIAttributes(
-          this.props.state,
-          {
-            storeId: this.toPublicStoreId(expression.storeId),
-          },
-          firstPartyIsolate,
-        ),
+        returnOptionalCookieAPIAttributes(this.props.state, {
+          storeId: this.toPublicStoreId(expression.storeId),
+        }),
       );
       const regExp = new RegExp(exp.slice(7)); // take out file://
       cookies = allCookies.filter(
@@ -122,14 +112,10 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
       );
     } else {
       cookies = await browser.cookies.getAll(
-        returnOptionalCookieAPIAttributes(
-          this.props.state,
-          {
-            domain: `${trimDotAndStar(exp)}${exp.endsWith('.') ? '.' : ''}`,
-            storeId: this.toPublicStoreId(expression.storeId),
-          },
-          firstPartyIsolate,
-        ),
+        returnOptionalCookieAPIAttributes(this.props.state, {
+          domain: `${trimDotAndStar(exp)}${exp.endsWith('.') ? '.' : ''}`,
+          storeId: this.toPublicStoreId(expression.storeId),
+        }),
       );
     }
     this.setState({ cookies });

--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -27,6 +27,7 @@ import {
 import {
   CADCOOKIENAME,
   extractMainDomain,
+  getAllCookiesForDomain,
   getHostname,
   getSetting,
   isAnIP,
@@ -34,7 +35,6 @@ import {
   isFirefoxNotAndroid,
   localFileToRegex,
   parseCookieStoreId,
-  returnOptionalCookieAPIAttributes,
 } from '../../services/Libs';
 import { FilterOptions } from '../../typings/Enums';
 import { ReduxAction } from '../../typings/ReduxConstants';
@@ -157,21 +157,17 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
     return result;
   }
 
-  public async setPopupCookieCount(hostname: string) {
+  public async setPopupCookieCount() {
     const { state } = this.props;
-    if (!this.state.tab) return;
-    const { cookieStoreId } = this.state.tab;
-    const cookies = await browser.cookies.getAll(
-      returnOptionalCookieAPIAttributes(state, {
-        domain: hostname,
-        firstPartyDomain: extractMainDomain(hostname),
-        storeId: cookieStoreId,
-      }),
-    );
+    const { tab } = this.state;
+    if (!tab || !tab.url) return;
+    const cookies = await getAllCookiesForDomain(state, tab);
+
     this.setState({
-      cookieCount:
-        cookies.length -
-        cookies.filter((cookie) => cookie.name === CADCOOKIENAME).length,
+      cookieCount: cookies
+        ? cookies.length -
+          cookies.filter((cookie) => cookie.name === CADCOOKIENAME).length
+        : 0,
     });
   }
 
@@ -206,7 +202,7 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
         this.port.onMessage.addListener((m) => {
           const msg = m as CookieCountMsg;
           if (msg.cookieUpdated !== undefined && msg.cookieUpdated) {
-            this.setPopupCookieCount(hostname);
+            this.setPopupCookieCount();
           }
         });
         this.port.onDisconnect.addListener((p) => {

--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -32,7 +32,6 @@ import {
   isAnIP,
   isChrome,
   isFirefoxNotAndroid,
-  isFirstPartyIsolate,
   localFileToRegex,
   parseCookieStoreId,
   returnOptionalCookieAPIAttributes,
@@ -162,17 +161,12 @@ class App extends React.Component<PopupAppComponentProps, InitialState> {
     const { state } = this.props;
     if (!this.state.tab) return;
     const { cookieStoreId } = this.state.tab;
-    const firstPartyIsolate = await isFirstPartyIsolate();
     const cookies = await browser.cookies.getAll(
-      returnOptionalCookieAPIAttributes(
-        state,
-        {
-          domain: hostname,
-          firstPartyDomain: extractMainDomain(hostname),
-          storeId: cookieStoreId,
-        },
-        firstPartyIsolate,
-      ),
+      returnOptionalCookieAPIAttributes(state, {
+        domain: hostname,
+        firstPartyDomain: extractMainDomain(hostname),
+        storeId: cookieStoreId,
+      }),
     );
     this.setState({
       cookieCount:


### PR DESCRIPTION
This should fix #801.

In hindsight we should have allowed cookies stored using firstPartyIsolate to be removed even if firstPartyIsolate was (recently) disabled.  This should allow it.

~I'm having some difficulty writing test cases for these so they're not included....for the time being.~  Test Cases Added as of 50da8b4.