### PR TITLE
browsingData Patch

### DIFF
--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -83,6 +83,7 @@ const whiteListAllExceptTwitter: Expression = {
 
 const greyMessenger: Expression = {
   expression: 'messenger.com',
+  cleanSiteData: [SiteDataType.CACHE],
   id: '6',
   listType: ListType.GREY,
   storeId: 'firefox-container-1',
@@ -1369,16 +1370,32 @@ describe('CleanupService', () => {
       expect(result.cleanCookie).toBe(false);
     });
 
-    it('should return true if cookie was created through CAD', () => {
+    it('should return true if cookie was created through CAD with matching WHITE expression and at least one browsingData type for cleanup', () => {
       const cookieProperty = {
         ...mockCookie,
         name: CADCOOKIENAME,
-        hostname: 'sub.google.com',
+        hostname: 'youtube.com',
+        mainDomain: 'youtube.com',
+      };
+
+      const result = isSafeToClean(sampleState, cookieProperty, {
+        ...cleanupProperties,
+      });
+      expect(result.reason).toBe(ReasonClean.CADSiteDataCookie);
+      expect(result.cleanCookie).toBe(true);
+    });
+
+    it('should return true if cookie was created through CAD with matching GREY expression and at least one browsingData type for cleanup', () => {
+      const cookieProperty = {
+        ...mockCookie,
+        name: CADCOOKIENAME,
+        hostname: 'google.com',
         mainDomain: 'google.com',
       };
 
       const result = isSafeToClean(sampleState, cookieProperty, {
         ...cleanupProperties,
+        greyCleanup: true,
       });
       expect(result.reason).toBe(ReasonClean.CADSiteDataCookie);
       expect(result.cleanCookie).toBe(true);

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -172,7 +172,7 @@ describe('TabEvents', () => {
       expect(spyBrowserActions.checkIfProtected.mock.calls[0][2]).toBe(1);
     });
 
-    it('should create a cookie if clean cache was enabled and no cookie was found', async () => {
+    it('should create a cookie if clean cache was enabled and no CAD cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -184,7 +184,7 @@ describe('TabEvents', () => {
       expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
     });
 
-    it('should create a cookie if clean indexedDB was enabled and no cookie was found', async () => {
+    it('should create a cookie if clean indexedDB was enabled and no CAD cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -196,7 +196,7 @@ describe('TabEvents', () => {
       expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
     });
 
-    it('should create a cookie if clean localStorage was enabled and no cookie was found', async () => {
+    it('should create a cookie if clean localStorage was enabled and no CAD cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -208,7 +208,7 @@ describe('TabEvents', () => {
       expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
     });
 
-    it('should create a cookie if clean plugin data was enabled and no cookie was found', async () => {
+    it('should create a cookie if clean plugin data was enabled and no CAD cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -220,7 +220,7 @@ describe('TabEvents', () => {
       expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
     });
 
-    it('should create a cookie if clean service workers was enabled and no cookie was found', async () => {
+    it('should create a cookie if clean service workers was enabled and no CAD cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -254,6 +254,27 @@ describe('TabEvents', () => {
       expect(
         spyBrowserActions.showNumberOfCookiesInIcon,
       ).not.toHaveBeenCalled();
+    });
+
+    it('should create a cookie with firstPartyDomain if FPI is enabled', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
+        .mockResolvedValue([] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: '' })
+        .mockResolvedValueOnce([] as never)
+        .mockRejectedValue(new Error('firstPartyDomain') as never);
+      TestStore.changeSetting('cacheCleanup', true);
+      TestStore.addCache({ key: 'browserDetect', value: browserName.Firefox });
+
+      await TabEvents.getAllCookieActions({
+        ...sampleTab,
+        url: 'http://cookie.net',
+      });
+      expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
+      expect(global.browser.cookies.set.mock.calls[0][0]).toHaveProperty(
+        'firstPartyDomain',
+      );
     });
   });
 

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -382,7 +382,7 @@ export const cookieCleanup: ActionCreator<ThunkAction<
     if (siteDataCleaned && browsingDataCleanup) {
       const domainsAll: string[] = [];
       for (const domains of Object.values(browsingDataCleanup)) {
-        if (!domains || domains.length === 0) return;
+        if (!domains || domains.length === 0) continue;
         domainsAll.push(...domains);
       }
       if (domainsAll.length > 0) {

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -152,55 +152,32 @@ export const isSafeToClean = (
     hostname,
   );
 
-  // Internal CAD Cookie Checks -
-  // only return true w/ expression if cleanSiteData has something specific
+  // Internal CAD Cookie Checks
   if (
     matchedExpression &&
-    matchedExpression.cleanSiteData &&
-    cookieProperties.name === CADCOOKIENAME
+    cookieProperties.name === CADCOOKIENAME &&
+    (matchedExpression.listType === ListType.WHITE ||
+      (greyCleanup && matchedExpression.listType === ListType.GREY))
   ) {
-    if (greyCleanup && matchedExpression.listType === ListType.GREY) {
-      cadLog(
-        {
-          msg:
-            'CleanupService.isSafeToClean:  Internal CAD Cookie.  Removing Cookie to trigger browsingData cleanups on startup.',
-          x: {
-            partialCookieInfo,
-            cleanSiteData: matchedExpression.cleanSiteData,
-          },
+    cadLog(
+      {
+        msg:
+          'CleanupService.isSafeToClean:  Internal CAD Cookie.  Removing Cookie to trigger browsingData cleanups.',
+        x: {
+          partialCookieInfo,
+          cleanSiteData: matchedExpression.cleanSiteData,
         },
-        debug,
-      );
-      return {
-        cached: false,
-        cleanCookie: true,
-        cookie: cookieProperties,
-        expression: matchedExpression,
-        openTabStatus,
-        reason: ReasonClean.CADSiteDataCookie,
-      };
-    }
-    if (matchedExpression.listType === ListType.WHITE) {
-      cadLog(
-        {
-          msg:
-            'CleanupService.isSafeToClean:  Internal CAD Cookie.  Removing Cookie to trigger browsingData cleanups.',
-          x: {
-            partialCookieInfo,
-            cleanSiteData: matchedExpression.cleanSiteData,
-          },
-        },
-        debug,
-      );
-      return {
-        cached: false,
-        cleanCookie: true,
-        cookie: cookieProperties,
-        expression: matchedExpression,
-        openTabStatus,
-        reason: ReasonClean.CADSiteDataCookie,
-      };
-    }
+      },
+      debug,
+    );
+    return {
+      cached: false,
+      cleanCookie: true,
+      cookie: cookieProperties,
+      expression: matchedExpression,
+      openTabStatus,
+      reason: ReasonClean.CADSiteDataCookie,
+    };
   }
 
   // Startup cleanup checks

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,12 @@
 {
   "releases": [
     {
+      "version": "3.5.1",
+      "notes": [
+        "Fixed:  browsingData cleanup.  Remove Internal CAD Cookie from notifications and cleanup logs.  Closes #846."
+      ]
+    },
+    {
       "version": "3.5.0",
       "notes": [
         "MIGRATION NOTE 1:  'Uncheck Keep Localstorage on new expressions' has been deprecated in favor of default expression entries.  Those that have this enabled will see new default expression entries for all containers for that list type.  Only the localStorage option in the global default expression entry will be downgraded for use in 3.4.0!",


### PR DESCRIPTION
This fixes #846.

This also removes the internal CAD Cookie from being shown in the cleanup logs (but browsingData will still trigger).

In addition, this will always add an internal CAD Cookie for each site if one does not exist yet, regardless of any existing cookies.  This allows us to remove browsing data from those subdomain sites as they require the specific website.  Sometimes cookies are only set for the main domain despite accessing from a subdomain.