### PR TITLE
Localstorage Migration patch

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -87,11 +87,21 @@ const onSettingsChange = async () => {
     if (
       (previousSettings[sd] === undefined || !previousSettings[sd].value) &&
       currentSettings[sd].value
-    )
+    ) {
+      // Migration Check to prevent LocalStorage from being cleaned again.
+      // Only if migrating from 3.4.0 to 3.5.1+
+      if (
+        siteData === SiteDataType.LOCALSTORAGE &&
+        previousSettings['localstorageCleanup'] !== undefined &&
+        previousSettings['localstorageCleanup'].value
+      ) {
+        continue;
+      }
       await browsingDataCleanup(
         siteData,
         currentSettings.debugMode.value as boolean,
       );
+    }
   }
 
   if (previousSettings.activeMode.value && !currentSettings.activeMode.value) {

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,12 @@
 {
   "releases": [
     {
+      "version": "3.5.1",
+      "notes": [
+        "Fixed:  LocalStorage should not be fully cleaned if migrating from 3.4.0.  Closes #847."
+      ]
+    },
+    {
       "version": "3.5.0",
       "notes": [
         "MIGRATION NOTE 1:  'Uncheck Keep Localstorage on new expressions' has been deprecated in favor of default expression entries.  Those that have this enabled will see new default expression entries for all containers for that list type.  Only the localStorage option in the global default expression entry will be downgraded for use in 3.4.0!",


### PR DESCRIPTION
This should fix #847.

The only case where localstorage should not be cleaned upon activation is when we are migrating the setting from localstorageCleanup to localStorageCleanup.

Theoretically this should work.  It will skip cleaning localstorage only if localstorageCleanup is found and its value is true.