### PR TITLE
Validation for revised expressions.

### DIFF
--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -1699,7 +1699,7 @@ describe('Library Functions', () => {
     it('should return invalid message on end slash missing start slash', () => {
       validateExpressionDomain('abc/');
       expect(global.browser.i18n.getMessage).toHaveBeenCalledWith(
-        'inputErrorEndSlashMissingStart',
+        'inputErrorSlashEndMissingStart',
       );
     });
     it('should return invalid message on comma usage outside of RegExp', () => {

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -46,6 +46,7 @@ import {
   throwErrorNotification,
   trimDot,
   undefinedIsTrue,
+  validateExpressionDomain,
 } from '../../src/services/Libs';
 
 import ipaddr from 'ipaddr.js';
@@ -1667,6 +1668,61 @@ describe('Library Functions', () => {
     });
     it('should return false for false', () => {
       expect(undefinedIsTrue(false)).toEqual(false);
+    });
+  });
+
+  describe('validateExpressionDomain()', () => {
+    when(global.browser.i18n.getMessage)
+      .calledWith(expect.any(String))
+      .mockReturnValue('message');
+    when(global.browser.i18n.getMessage)
+      .calledWith(expect.any(String), expect.any(Array))
+      .mockReturnValue(`message with substitution array`);
+    it('should return invalid message on "" input', () => {
+      validateExpressionDomain('');
+      expect(global.browser.i18n.getMessage).toHaveBeenCalledWith(
+        'inputErrorEmpty',
+      );
+    });
+    it('should return invalid message on invalid RegExp', () => {
+      validateExpressionDomain('/abc(def]/');
+      expect(
+        global.browser.i18n.getMessage,
+      ).toHaveBeenCalledWith('inputErrorRegExp', [expect.any(String)]);
+    });
+    it('should return invalid message on start slash missing end slash', () => {
+      validateExpressionDomain('/abc');
+      expect(global.browser.i18n.getMessage).toHaveBeenCalledWith(
+        'inputErrorSlashStartMissingEnd',
+      );
+    });
+    it('should return invalid message on end slash missing start slash', () => {
+      validateExpressionDomain('abc/');
+      expect(global.browser.i18n.getMessage).toHaveBeenCalledWith(
+        'inputErrorEndSlashMissingStart',
+      );
+    });
+    it('should return invalid message on comma usage outside of RegExp', () => {
+      validateExpressionDomain('a,b');
+      expect(global.browser.i18n.getMessage).toHaveBeenCalledWith(
+        'inputErrorComma',
+      );
+    });
+    it('should return invalid message on spaces between words.', () => {
+      validateExpressionDomain('test expression');
+      expect(global.browser.i18n.getMessage).toHaveBeenCalledWith(
+        'inputErrorSpace',
+      );
+    });
+    it('should return empty string if valid domain expression', () => {
+      const r = validateExpressionDomain('test');
+      expect(global.browser.i18n.getMessage).not.toHaveBeenCalled();
+      expect(r).toEqual('');
+    });
+    it('should return empty string if valid RegExp', () => {
+      const r = validateExpressionDomain('/[Rr]eg[Ee]xp.com/');
+      expect(global.browser.i18n.getMessage).not.toHaveBeenCalled();
+      expect(r).toEqual('');
     });
   });
 });

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -339,6 +339,16 @@
     "message": "Import Core Settings",
     "description": "Import Core Settings"
   },
+  "importFileNotFound": {
+    "message": "File not found: $filename$",
+    "description": "File not found: $filename$.  Found in List of Expressions and CAD Settings.",
+    "placeholders": {
+      "filename": {
+        "content": "$1",
+        "example": "filename.json"
+      }
+    }
+  },
   "importFileTypeInvalid": {
     "message": "File given is not a type we handle",
     "description": "File given is not a type we handle"
@@ -347,6 +357,20 @@
     "message": "File given failed validation",
     "description": "File given failed validation"
   },
+  "importInvalidExpressions": {
+    "message": "Detected invalid expression(s) from file import. They are noted below with its reason. Check and fix any errors in that file and try importing again.",
+    "description": "Detected invalid expression(s) from file import. They are noted below with its reason. Check and fix any errors in that file and try importing again. Found in List of Expressions when imported file as expressions that aren't valid."
+  },
+  "importListNotArray": {
+    "message": "$identifier$ is not formatted as an array list.",
+    "description": "$identifier$ is not formatted as an array list.  Found in List of Expressions during import validation.",
+    "placeholders":{
+      "identifier": {
+        "content": "$1",
+        "example": "jsonObjectKey"
+      }
+    }
+  },
   "importMissingKey": {
     "message": "Missing identifier",
     "description": "Missing identifier"
@@ -354,6 +378,20 @@
   "importURLSText": {
     "message": "Import Expressions",
     "description": "Import Expressions"
+  },
+  "importValidExpressions": {
+    "message": "Successfully added $num$ expression(s) from imported file: $filename$.",
+    "description": "Successfully added $num$ expression(s) from imported file: $filename$.  Found in List of Expressions after successful valid expressions from import.",
+    "placeholders": {
+      "num": {
+        "content": "$1",
+        "example": "5"
+      },
+      "filename": {
+        "content": "$2",
+        "example": "filename.json"
+      }
+    }
   },
   "indexedDBCleanupText": {
     "message": "Enable IndexedDB Cleanup (Firefox 77+, Chrome 74+)",
@@ -392,6 +430,20 @@
   "inputErrorSpace": {
     "message": "Spaces are not allowed in hostnames.",
     "description": "Spaces are not allowed in hostnames. Found in editing expression errors."
+  },
+  "inputAddSuccess": {
+    "message": "Successfully added $num$ expression(s) with $listType$ Type in the currently active list.",
+    "description": "Successfully added $num$ expression(s) to $listType$ Type in the currently active list.  Found in List of Expressions after successful inputs.",
+    "placeholders": {
+      "num": {
+        "content": "$1",
+        "example": "5"
+      },
+      "listType": {
+        "content": "$2",
+        "example": "GreyList"
+      }
+    }
   },
   "invalidNewExpressions": {
     "message": "Detected invalid new expression(s). They are noted below with its reason and have been kept above for editing.",
@@ -832,16 +884,6 @@
   "reasonTabsWereNotIgnored": {
     "message": "or in any open tabs",
     "description": "[Clean because of sub.google.com is not in the White or Grey lists] or in any open tabs"
-  },
-  "regexMissingEndSlash": {
-    "message": "NOTE:  A recently added expression has start slash but not end slash.  Both are required for regex matching.  Expression(s) noted:  $errDomains$",
-    "description": "NOTE:  A recently added expression has start slash but not end slash.  Both are required for regex matching.  Expression(s) noted:  $errDomains$.  Only if entering a new expression that starts with a slash and does not end with one. Can be found in List of Expressions.",
-    "placeholders": {
-      "errDomains": {
-        "content": "$1",
-        "example": "/regex"
-      }
-    }
   },
   "regularExpressionEquivalentText": {
     "message": "Regular Expression Equivalent",

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -363,6 +363,32 @@
     "message": "IndexedDB",
     "description": "IndexedDB.  Primarily used in notifications."
   },
+  "inputErrorComma": {
+    "message": "Commas are only allowed in Regular Expressions.",
+    "description": "Commas are only allowed in Regular Expressions.  Found in editing expression errors."
+  },
+  "inputErrorEmpty": {
+    "message": "Revised expression cannot be empty!",
+    "description": "Revised expression cannot be empty!  Found in editing expression errors."
+  },
+  "inputErrorRegExp": {
+    "message": "Regular Expression is not valid.  $RegexError$",
+    "description": "Regular Expression is not valid.  <Error from new RegExp()>.  Found in editing expression errors.",
+    "placeholders": {
+      "RegexError": {
+        "content": "$1",
+        "example": "SyntaxError:  unterminated character class."
+      }
+    }
+  },
+  "inputErrorSlashEndMissingStart": {
+    "message": "End slash missing start slash for Regular Expression.  Remove end slash for domains.",
+    "description": "End slash missing start slash for Regular Expression.  Remove end slash for domains.  Found in editing expression errors."
+  },
+  "inputErrorSlashStartMissingEnd": {
+    "message": "Start slash missing end slash for Regular Expression.",
+    "description": "Start slash missing end slash for Regular Expression.  Found in editing expression errors."
+  },
   "keepAllCookiesText": {
     "message": "Keep All Cookies",
     "description": "Keep All Cookies. Found in Expression Options. For Whitelist entries."

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -389,6 +389,10 @@
     "message": "Start slash missing end slash for Regular Expression.",
     "description": "Start slash missing end slash for Regular Expression.  Found in editing expression errors."
   },
+  "inputErrorSpace": {
+    "message": "Spaces are not allowed in hostnames.",
+    "description": "Spaces are not allowed in hostnames.  Found in editing expression errors."
+  },
   "keepAllCookiesText": {
     "message": "Keep All Cookies",
     "description": "Keep All Cookies. Found in Expression Options. For Whitelist entries."

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -13,7 +13,7 @@
   },
   "activityLogSiteDataDomainsText": {
     "message": "Invoked cleanup of $siteData$ for: $domains$",
-    "description": "Invoked cleanup of $siteData$ for: $domains$.  Found in Activity Log Detailed Entries.",
+    "description": "Invoked cleanup of $siteData$ for: $domains$. Found in Activity Log Detailed Entries.",
     "placeholders": {
       "siteData": {
         "content": "$1",
@@ -27,7 +27,7 @@
   },
   "addNewExpressionNotification": {
     "message": "Adding $expression$ to list type $listType$ under cookie store $cookieStore$.",
-    "description": "Adding $expression$ to list type $listType$ under cookie store $cookieStore$.  Used in notification when right-click action was performed.",
+    "description": "Adding $expression$ to list type $listType$ under cookie store $cookieStore$. Used in notification when right-click action was performed.",
     "placeholders": {
       "expression": {
         "content": "$1",
@@ -49,7 +49,7 @@
   },
   "addNewExpressionNotificationIgnore": {
     "message": "If expression already exists, this will be ignored.",
-    "description": "If expression already exists, this will be ignored.  Used in notification when right-click action was performed."
+    "description": "If expression already exists, this will be ignored. Used in notification when right-click action was performed."
   },
   "autoDeleteDisabledText": {
     "message": "Auto-clean disabled",
@@ -61,31 +61,31 @@
   },
   "browsingDataWarning": {
     "message": "WARNING:  Upon enabling any of the following site data cleanup options, ALL existing data for that type will be cleared.",
-    "description": "WARNING:  Upon enabling any of the following site data cleanup options, ALL existing data for that type will be cleared.  Found in CAD Settings"
+    "description": "WARNING:  Upon enabling any of the following site data cleanup options, ALL existing data for that type will be cleared. Found in CAD Settings"
   },
   "cacheCleanupText": {
     "message": "Enable Cache Cleanup (Firefox 78+, Chrome 74+)",
-    "description": "Enable Cache Cleanup (Firefox 78+, Chrome 74+).  Found in CAD Settings."
+    "description": "Enable Cache Cleanup (Firefox 78+, Chrome 74+). Found in CAD Settings."
   },
   "cacheText": {
     "message": "Cache",
-    "description": "Cache.  Primarily used in notifications."
+    "description": "Cache. Primarily used in notifications."
   },
   "chromeDebugMode": {
     "message": "Ensure 'Developer Mode' is enabled, then click on 'background page' under Inspect View.",
-    "description": "Ensure 'Developer Mode' is enabled, then click on 'background page' under Inspect View.  This is shown if debug mode is enabled."
+    "description": "Ensure 'Developer Mode' is enabled, then click on 'background page' under Inspect View. This is shown if debug mode is enabled."
   },
   "cleanDiscardedText": {
     "message": "Enable Cleanup for Discarded/Unloaded Tabs",
-    "description": "Enable Cleanup for Discarded/Unloaded Tabs.  Found in Settings."
+    "description": "Enable Cleanup for Discarded/Unloaded Tabs. Found in Settings."
   },
   "cleanExpiredCookiesText": {
     "message": "Clean All Expired Cookies",
-    "description": "Clean All Expired Cookies.  Found in Settings."
+    "description": "Clean All Expired Cookies. Found in Settings."
   },
   "cleanIgnoringOpenTabsText": {
     "message": "Clean, include open tabs",
-    "description": "Clean, include open tabs.  Found in the additional cleanup options in the popup."
+    "description": "Clean, include open tabs. Found in the additional cleanup options in the popup."
   },
   "cleanText": {
     "message": "Clean",
@@ -113,31 +113,31 @@
   },
   "consoleDebugMode": {
     "message": "Click on the Console Tab",
-    "description": "Click on the Console Tab.  Found after enabling debug mode."
+    "description": "Click on the Console Tab. Found after enabling debug mode."
   },
   "containerSiteDataWarning": {
-    "message": "WARNING:  Enabling Container Tabs with any of the additional browsing data cleanups above may cause unwanted side effects due to browser API limitations.  Site data types, with the exception of cookies, will be cleared by hostname for ALL containers.",
-    "description": "WARNING:  Enabling Container Tabs with any of the additional browsing data cleanups above may cause unwanted side effects due to browser API limitations.  Site data types, with the exception of cookies, will be cleared by hostname for ALL containers.  Found in CAD Settings."
+    "message": "WARNING:  Enabling Container Tabs with any of the additional browsing data cleanups above may cause unwanted side effects due to browser API limitations. Site data types, with the exception of cookies, will be cleared by hostname for ALL containers.",
+    "description": "WARNING:  Enabling Container Tabs with any of the additional browsing data cleanups above may cause unwanted side effects due to browser API limitations. Site data types, with the exception of cookies, will be cleared by hostname for ALL containers. Found in CAD Settings."
   },
   "contextMenusParentClean": {
     "message": "Manual Cleaning Menu",
-    "description": "Manual Cleaning Menu.  Shown on right-clicks of Page/Browser Action."
+    "description": "Manual Cleaning Menu. Shown on right-clicks of Page/Browser Action."
   },
   "contextMenusParentExpression": {
     "message": "Add Domain/Expression Menu",
-    "description": "Add Domain/Expression Menu.  Shown on right-clicks of Page/Link/Selection."
+    "description": "Add Domain/Expression Menu. Shown on right-clicks of Page/Link/Selection."
   },
   "contextMenusSelectedDomainLink": {
     "message": "For domain only of selected link",
-    "description": "For domain only of selected link.  Shown in right-click menu."
+    "description": "For domain only of selected link. Shown in right-click menu."
   },
   "contextMenusSelectedDomainPage": {
     "message": "For domain only of selected page",
-    "description": "For domain only of selected page.  Shown in right-click menu."
+    "description": "For domain only of selected page. Shown in right-click menu."
   },
   "contextMenusSelectedDomainText": {
     "message": "For domain only of selected text: $selected$",
-    "description": "For domain only of selected text: $selected$.  Shown in right-click menu.",
+    "description": "For domain only of selected text: $selected$. Shown in right-click menu.",
     "placeholders": {
       "selected": {
         "content": "$1",
@@ -147,15 +147,15 @@
   },
   "contextMenusSelectedSubdomainLink": {
     "message": "For all subdomains with domain of selected link",
-    "description": "For all subdomains with domain of selected link.  Shown in right-click menu."
+    "description": "For all subdomains with domain of selected link. Shown in right-click menu."
   },
   "contextMenusSelectedSubdomainPage": {
     "message": "For all subdomains with domain of selected page",
-    "description": "For all subdomains with domain of selected page.  Shown in right-click menu."
+    "description": "For all subdomains with domain of selected page. Shown in right-click menu."
   },
   "contextMenusSelectedSubdomainText": {
     "message": "For all subdomains with domain of selected text: $selected$",
-    "description": "For all subdomains with domain of selected text.  Shown in right-click menu.",
+    "description": "For all subdomains with domain of selected text. Shown in right-click menu.",
     "placeholders": {
       "selected": {
         "content": "$1",
@@ -165,11 +165,11 @@
   },
   "contextualIdentitiesAutoRemoveText": {
     "message": "Enable Automatic Removal of Expression List when its Container is Removed.",
-    "description": "Enable Automatic Removal of Expression List when its Container is Removed.  Only in Firefox."
+    "description": "Enable Automatic Removal of Expression List when its Container is Removed. Only in Firefox."
   },
   "contextualIdentitiesEnabledText": {
     "message": "Enable Support for Firefox's Container Tabs",
-    "description": "Enable Support for Firefox's Container Tabs.  Only in Firefox."
+    "description": "Enable Support for Firefox's Container Tabs. Only in Firefox."
   },
   "contributeText": {
     "message": "Contribute",
@@ -181,7 +181,7 @@
   },
   "cookiesText": {
     "message": "Cookies",
-    "description": "Cookies.  Primarily used in popup via alternate clean action dropdown."
+    "description": "Cookies. Primarily used in popup via alternate clean action dropdown."
   },
   "cookieCleanUpOnStartText": {
     "message": "Clean Cookies from Open Tabs on Startup",
@@ -189,7 +189,7 @@
   },
   "cookieCleanupIgnoreOpenTabsText": {
     "message": "Run cleanup now, include domains from open tabs",
-    "description": "Run cleanup now, include cookies from open tabs.  This is shown on mouseover from the available dropdown buttons."
+    "description": "Run cleanup now, include cookies from open tabs. This is shown on mouseover from the available dropdown buttons."
   },
   "cookieCleanupText": {
     "message": "Run cleanup now, exclude domains from open tabs",
@@ -197,11 +197,11 @@
   },
   "createDefaultExpressionOptionsText": {
     "message": "Create Default Expression Options",
-    "description": "Create Default Expression Options.  Used in 'List of Expressions'"
+    "description": "Create Default Expression Options. Used in 'List of Expressions'"
   },
   "currentContainerInfo": {
     "message": "Current Container Selected:  $ID$ ( $Name$ )",
-    "description": "Current Container Selected:  $ID$ ( $Name ).  Found in List of Expressions only if Firefox containers enabled.",
+    "description": "Current Container Selected:  $ID$ ( $Name ). Found in List of Expressions only if Firefox containers enabled.",
     "placeholders": {
       "ID": {
         "content": "$1",
@@ -219,11 +219,11 @@
   },
   "defaultText": {
     "message": "Default",
-    "description": "Default.  Used in List of Expression in Firefox for Default / No Container."
+    "description": "Default. Used in List of Expression in Firefox for Default / No Container."
   },
   "defaultContainerText": {
     "message": "No Container",
-    "description": "No Container.  This will be in brackets.  Used in List of Expression in Firefox for Default / No Container"
+    "description": "No Container. This will be in brackets. Used in List of Expression in Firefox for Default / No Container"
   },
   "defaultSettingsText": {
     "message": "Restore Default Settings",
@@ -243,7 +243,7 @@
   },
   "domainPlaceholderText": {
     "message": "example.com, subdomain.example.com, *.example.com, /(^|.)example\\.com/",
-    "description": "Domain Expression.  For this one we'll keep the string as is."
+    "description": "Domain Expression. For this one we'll keep the string as is."
   },
   "dropdownAdditionalCleaningOptions": {
     "message": "Toggle Additional Cleaning Actions Dropdown",
@@ -263,7 +263,7 @@
   },
   "enableContextMenus": {
     "message": "Enable Context Menus (Right-Click Menu)",
-    "description": "Enable Context Menus (Right-Click Menu).  Shown in CAD Settings"
+    "description": "Enable Context Menus (Right-Click Menu). Shown in CAD Settings"
   },
   "enableGlobalSubdomainText": {
     "message": "Enable Check for Subdomains",
@@ -307,7 +307,7 @@
   },
   "filterDebugMode": {
     "message": "To see only debug outputs by this extension, filter output by the following line:",
-    "description": "To see only debug outputs by this extension, filter output by the following line.  Found after enabling debug mode."
+    "description": "To see only debug outputs by this extension, filter output by the following line. Found after enabling debug mode."
   },
   "filterText": {
     "message": "Filter",
@@ -357,23 +357,23 @@
   },
   "indexedDBCleanupText": {
     "message": "Enable IndexedDB Cleanup (Firefox 77+, Chrome 74+)",
-    "description": "Enable IndexedDB Cleanup (Firefox 77+, Chrome 74+).  Found in CAD Settings."
+    "description": "Enable IndexedDB Cleanup (Firefox 77+, Chrome 74+). Found in CAD Settings."
   },
   "indexedDBText": {
     "message": "IndexedDB",
-    "description": "IndexedDB.  Primarily used in notifications."
+    "description": "IndexedDB. Primarily used in notifications."
   },
   "inputErrorComma": {
     "message": "Commas are only allowed in Regular Expressions.",
-    "description": "Commas are only allowed in Regular Expressions.  Found in editing expression errors."
+    "description": "Commas are only allowed in Regular Expressions. Found in editing expression errors."
   },
   "inputErrorEmpty": {
     "message": "Revised expression cannot be empty!",
     "description": "Revised expression cannot be empty!  Found in editing expression errors."
   },
   "inputErrorRegExp": {
-    "message": "Regular Expression is not valid.  $RegexError$",
-    "description": "Regular Expression is not valid.  <Error from new RegExp()>.  Found in editing expression errors.",
+    "message": "Regular Expression is not valid. $RegexError$",
+    "description": "Regular Expression is not valid. <Error from new RegExp()>. Found in editing expression errors.",
     "placeholders": {
       "RegexError": {
         "content": "$1",
@@ -382,16 +382,20 @@
     }
   },
   "inputErrorSlashEndMissingStart": {
-    "message": "End slash missing start slash for Regular Expression.  Remove end slash for domains.",
-    "description": "End slash missing start slash for Regular Expression.  Remove end slash for domains.  Found in editing expression errors."
+    "message": "End slash missing start slash for Regular Expression. Remove end slash for domains.",
+    "description": "End slash missing start slash for Regular Expression. Remove end slash for domains. Found in editing expression errors."
   },
   "inputErrorSlashStartMissingEnd": {
     "message": "Start slash missing end slash for Regular Expression.",
-    "description": "Start slash missing end slash for Regular Expression.  Found in editing expression errors."
+    "description": "Start slash missing end slash for Regular Expression. Found in editing expression errors."
   },
   "inputErrorSpace": {
     "message": "Spaces are not allowed in hostnames.",
-    "description": "Spaces are not allowed in hostnames.  Found in editing expression errors."
+    "description": "Spaces are not allowed in hostnames. Found in editing expression errors."
+  },
+  "invalidNewExpressions": {
+    "message": "Detected invalid new expression(s). They are noted below with its reason and have been kept above for editing.",
+    "description": "Detected invalid new expression(s). They are noted below with its reason and have been kept above for editing. Found in List of Expressions Settings Page."
   },
   "keepAllCookiesText": {
     "message": "Keep All Cookies",
@@ -411,7 +415,7 @@
   },
   "keepDefaultIcon": {
     "message": "Keep Default Icons on all list types",
-    "description": "Keep Default Icons on all list types.  Disabled: keep blue icon, grey for automatic cleaning disabled.  Enabled: red/yellow/blue depending on matching expressions in list."
+    "description": "Keep Default Icons on all list types. Disabled: keep blue icon, grey for automatic cleaning disabled. Enabled: red/yellow/blue depending on matching expressions in list."
   },
   "keepIndexedDBText": {
     "message": "Keep IndexedDB",
@@ -455,11 +459,11 @@
   },
   "localStorageCleanupText": {
     "message": "Enable LocalStorage Cleanup (Firefox 58+, Chrome 74+)",
-    "description": "Enable LocalStorage Cleanup (Firefox 58+, Chrome 74+).  Found in CAD Settings."
+    "description": "Enable LocalStorage Cleanup (Firefox 58+, Chrome 74+). Found in CAD Settings."
   },
   "localStorageText": {
     "message": "LocalStorage",
-    "description": "LocalStorage.  Primarily used in notifications."
+    "description": "LocalStorage. Primarily used in notifications."
   },
   "manualActionNotification": {
     "message": "Manual Action Notification",
@@ -467,7 +471,7 @@
   },
   "manualCleanError": {
     "message": "$siteData$ cannot be cleaned for tab:",
-    "description": "$siteData$  cannot be cleaned for tab:.  Shown as notification if manual clean cookies cannot be done.",
+    "description": "$siteData$ cannot be cleaned for tab:. Shown as notification if manual clean cookies cannot be done.",
     "placeholders": {
       "siteData": {
         "content": "$1",
@@ -477,7 +481,7 @@
   },
   "manualCleanNothing": {
     "message": "No $siteData$ were found for cleaning on $url$.",
-    "description": "No $siteData$ were found for cleaning on $url$.  Used in notification after manual clean.",
+    "description": "No $siteData$ were found for cleaning on $url$. Used in notification after manual clean.",
     "placeholders": {
       "siteData": {
         "content": "$1",
@@ -491,7 +495,7 @@
   },
   "manualCleanRemoved": {
     "message": "Removed $deleted$ of $total$.",
-    "description": "Removed $deleted$ of $total$.  Used as part of success notification on manual clean.",
+    "description": "Removed $deleted$ of $total$. Used as part of success notification on manual clean.",
     "placeholders": {
       "deleted": {
         "content": "$1",
@@ -505,11 +509,11 @@
   },
   "manualCleanSiteDataAll": {
     "message": "Clean All for this domain",
-    "description": "Clean All for this domain.  Found in Popup clean dropdown menu."
+    "description": "Clean All for this domain. Found in Popup clean dropdown menu."
   },
   "manualCleanSiteDataAllDomain": {
     "message": "Clear all site data for $domain$",
-    "description": "Clear all site data for $domain$.  Found in Popup clean dropdown menu as mouseover.",
+    "description": "Clear all site data for $domain$. Found in Popup clean dropdown menu as mouseover.",
     "placeholders": {
       "domain": {
         "content": "$1",
@@ -519,11 +523,11 @@
   },
   "manualCleanSiteDataCache": {
     "message": "Clean Cache for this domain",
-    "description": "Clean Cache for this domain.  Found in Popup clean dropdown menu."
+    "description": "Clean Cache for this domain. Found in Popup clean dropdown menu."
   },
   "manualCleanSiteDataCacheDomain": {
     "message": "Clear all Cache for $domain$",
-    "description": "Clear all Cache for $domain$.  Found in Popup clean dropdown menu as mouseover.",
+    "description": "Clear all Cache for $domain$. Found in Popup clean dropdown menu as mouseover.",
     "placeholders": {
       "domain": {
         "content": "$1",
@@ -533,11 +537,11 @@
   },
   "manualCleanSiteDataCookies": {
     "message": "Clean Cookies for this domain",
-    "description": "Clean Cookies for this domain.  Found in Popup clean dropdown menu."
+    "description": "Clean Cookies for this domain. Found in Popup clean dropdown menu."
   },
   "manualCleanSiteDataCookiesDomain": {
     "message": "Clear all Cookies for $domain$",
-    "description": "Clear all Cookies for $domain$.  Found in Popup clean dropdown menu as mouseover.",
+    "description": "Clear all Cookies for $domain$. Found in Popup clean dropdown menu as mouseover.",
     "placeholders": {
       "domain": {
         "content": "$1",
@@ -547,11 +551,11 @@
   },
   "manualCleanSiteDataIndexedDB": {
     "message": "Clean IndexedDB for this domain",
-    "description": "Clean IndexedDB for this domain.  Found in Popup clean dropdown menu."
+    "description": "Clean IndexedDB for this domain. Found in Popup clean dropdown menu."
   },
   "manualCleanSiteDataIndexedDBDomain": {
     "message": "Clear all IndexedDB for $domain$",
-    "description": "Clear all IndexedDB for $domain$.  Found in Popup clean dropdown menu as mouseover.",
+    "description": "Clear all IndexedDB for $domain$. Found in Popup clean dropdown menu as mouseover.",
     "placeholders": {
       "domain": {
         "content": "$1",
@@ -561,11 +565,11 @@
   },
   "manualCleanSiteDataLocalStorage": {
     "message": "Clean LocalStorage for this domain",
-    "description": "Clean LocalStorage for this domain.  Found in Popup clean dropdown menu."
+    "description": "Clean LocalStorage for this domain. Found in Popup clean dropdown menu."
   },
   "manualCleanSiteDataLocalStorageDomain": {
     "message": "Clear all LocalStorage for $domain$",
-    "description": "Clear all LocalStorage for $domain$.  Found in Popup clean dropdown menu as mouseover.",
+    "description": "Clear all LocalStorage for $domain$. Found in Popup clean dropdown menu as mouseover.",
     "placeholders": {
       "domain": {
         "content": "$1",
@@ -575,11 +579,11 @@
   },
   "manualCleanSiteDataPluginData": {
     "message": "Clean Plugin Data for this domain",
-    "description": "Clean Plugin Data for this domain.  Found in Popup clean dropdown menu."
+    "description": "Clean Plugin Data for this domain. Found in Popup clean dropdown menu."
   },
   "manualCleanSiteDataPluginDataDomain": {
     "message": "Clear all Plugin Data for $domain$",
-    "description": "Clear all Plugin Data for $domain$.  Found in Popup clean dropdown menu as mouseover.",
+    "description": "Clear all Plugin Data for $domain$. Found in Popup clean dropdown menu as mouseover.",
     "placeholders": {
       "domain": {
         "content": "$1",
@@ -589,11 +593,11 @@
   },
   "manualCleanSiteDataServiceWorkers": {
     "message": "Clean Service Workers for this domain",
-    "description": "Clean Service Workers for this domain.  Found in Popup clean dropdown menu."
+    "description": "Clean Service Workers for this domain. Found in Popup clean dropdown menu."
   },
   "manualCleanSiteDataServiceWorkersDomain": {
     "message": "Clear all Service Workers for $domain$",
-    "description": "Clear all Service Workers for $domain$.  Found in Popup clean dropdown menu as mouseover.",
+    "description": "Clear all Service Workers for $domain$. Found in Popup clean dropdown menu as mouseover.",
     "placeholders": {
       "domain": {
         "content": "$1",
@@ -617,7 +621,7 @@
   },
   "manualNotificationsText": {
     "message": "Show Notification from Manual Site Data Cleanups",
-    "description": "Show Notification from Manual Site Data Cleanups.  Found in settings"
+    "description": "Show Notification from Manual Site Data Cleanups. Found in settings"
   },
   "matchedDomainExpressionText": {
     "message": "Matched Domain Expression",
@@ -625,7 +629,7 @@
   },
   "menuText": {
     "message": "Menu",
-    "description": "Menu.  Only shown when the settings screen is small / when the hamburger icon shows / when the menu is collapsed."
+    "description": "Menu. Only shown when the settings screen is small / when the hamburger icon shows / when the menu is collapsed."
   },
   "minutesText": {
     "message": "minute(s)",
@@ -633,7 +637,7 @@
   },
   "missingContainerText": {
     "message": "INVALID CONTAINER",
-    "description": "INVALID CONTAINER.  Shown when a CAD list exists but cannot link id to available containers (Firefox)."
+    "description": "INVALID CONTAINER. Shown when a CAD list exists but cannot link id to available containers (Firefox)."
   },
   "noCleanupLogText": {
     "message": "No Cleanup Logs Found",
@@ -699,7 +703,7 @@
   },
   "notifyCookieCleanUpText": {
     "message": "Show Notification After Automatic Cleanup",
-    "description": "Show Notification After Automatic Cleanup.  Found in settings."
+    "description": "Show Notification After Automatic Cleanup. Found in settings."
   },
   "oldReleasesText": {
     "message": "Older release notes can be viewed online at",
@@ -715,11 +719,11 @@
   },
   "pluginDataCleanupText": {
     "message": "Enable Plugin Data Cleanup (Firefox 78+, Chrome 74+)",
-    "description": "Enable Plugin Data Cleanup (Firefox 78+, Chrome 74+).  Found in CAD Settings."
+    "description": "Enable Plugin Data Cleanup (Firefox 78+, Chrome 74+). Found in CAD Settings."
   },
   "pluginDataText": {
     "message": "Plugin Data",
-    "description": "Plugin Data.  Primarily used in notifications."
+    "description": "Plugin Data. Primarily used in notifications."
   },
   "popupCookieCountText": {
     "message": "Cookie(s)",
@@ -735,7 +739,7 @@
   },
   "reasonCADSiteDataCookie": {
     "message": "Clean to trigger Site Data cleaning for $hostname$.",
-    "description": "Clean to trigger Site Data cleaning for $hostname$.  Found in Activity Log Detailed Entries.",
+    "description": "Clean to trigger Site Data cleaning for $hostname$. Found in Activity Log Detailed Entries.",
     "placeholders": {
       "hostname": {
         "content": "$1",
@@ -755,7 +759,7 @@
   },
   "reasonCleanCookieName": {
     "message": "Partial clean because of matched $matchedExpression$ in the $listType$",
-    "description": "Partial clean because of matched $matchedExpression$ in the $listType$.  Used in cleanup logs.",
+    "description": "Partial clean because of matched $matchedExpression$ in the $listType$. Used in cleanup logs.",
     "placeholders": {
       "matchedExpression": {
         "content": "$1",
@@ -849,7 +853,7 @@
   },
   "removeActivityLogEntryText": {
     "message": "Remove Log Entry",
-    "description": "Remove Log Entry.  Shown in summary activity log for individual log removal."
+    "description": "Remove Log Entry. Shown in summary activity log for individual log removal."
   },
   "removeAllExpressions": {
     "message": "Remove All Expressions",
@@ -857,7 +861,7 @@
   },
   "removeAllExpressionsConfirm": {
     "message": "Are you sure you want to remove ALL ($expressionCount$) saved expression(s) from ($listCount$) list(s)?\n\nTHIS CANNOT BE UNDONE!\n\nType [ $expressionCount$ ] and click OK to delete.",
-    "description": "Are you sure you want to remove ALL ($expressionCount$) saved expression(s) from ($listCount$) list(s)?\n\nTHIS CANNOT BE UNDONE!\n\nType [ $expressionCount$ ] and click OK to delete.  Popup prompt if Delete All Expression is clicked.",
+    "description": "Are you sure you want to remove ALL ($expressionCount$) saved expression(s) from ($listCount$) list(s)?\n\nTHIS CANNOT BE UNDONE!\n\nType [ $expressionCount$ ] and click OK to delete. Popup prompt if Delete All Expression is clicked.",
     "placeholders": {
       "expressionCount": {
         "content": "$1",
@@ -879,7 +883,7 @@
   },
   "removeListText": {
     "message": "Remove All Expressions from Selected List",
-    "description": "Remove All Expressions from Selected List.  Shown in List of Expressions, only on Firefox and if containers/contextual identities is enabled."
+    "description": "Remove All Expressions from Selected List. Shown in List of Expressions, only on Firefox and if containers/contextual identities is enabled."
   },
   "removeStorageCount": {
     "message": "Removed $count$ item(s) from $storageType$.",
@@ -901,7 +905,7 @@
   },
   "resetCookieCounterText": {
     "message": "Reset Cookie Counters",
-    "description": "Reset Cookie Counters.  Button in Welcome Page."
+    "description": "Reset Cookie Counters. Button in Welcome Page."
   },
   "resetExtensionDataText": {
     "message": "Reset Extension Data",
@@ -931,15 +935,15 @@
   },
   "serviceWorkersCleanupText": {
     "message": "Enable Service Workers Cleanup (Firefox 77+, Chrome 74+)",
-    "description": "Enable Service Workers Cleanup (Firefox 77+, Chrome 74+).  Found in CAD Settings."
+    "description": "Enable Service Workers Cleanup (Firefox 77+, Chrome 74+). Found in CAD Settings."
   },
   "serviceWorkersText": {
     "message": "Service Workers",
-    "description": "Service Workers.  Primarily used in notifications."
+    "description": "Service Workers. Primarily used in notifications."
   },
   "sessionStorageText": {
     "message": "SessionStorage",
-    "description": "SessionStorage.  Used in manual localstorage clean notification"
+    "description": "SessionStorage. Used in manual localstorage clean notification"
   },
   "settingGroupAutoClean": {
     "message": "Automatic Cleaning Options",
@@ -973,15 +977,15 @@
   },
   "siteDataText": {
     "message": "Site Data",
-    "description": "Site Data.  Found in Activity Log Summary and Notifications."
+    "description": "Site Data. Found in Activity Log Summary and Notifications."
   },
   "sizePopupText": {
     "message": "Size of Popup (in px)",
-    "description": "Size of Popup (in px).  This sets the font size in the Popup."
+    "description": "Size of Popup (in px). This sets the font size in the Popup."
   },
   "sizeSettingText": {
     "message": "Size of Setting Pages (in px)",
-    "description": "Size of Setting Pages (in px).  This sets the font size in the Setting Pages."
+    "description": "Size of Setting Pages (in px). This sets the font size in the Setting Pages."
   },
   "stopEditingText": {
     "message": "Stop editing",
@@ -1013,7 +1017,7 @@
   },
   "versionNumberText": {
     "message": "$CAD$ version",
-    "description": "$CAD$ version 3.2.1.  The actual number is formatted differently and will be right below this text.",
+    "description": "$CAD$ version 3.2.1. The actual number is formatted differently and will be right below this text.",
     "placeholders": {
       "CAD": {
         "content": "$1",

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -2,6 +2,10 @@
   cursor: pointer;
 }
 
+.alertPreWrap {
+  white-space: pre-wrap;
+}
+
 label:hover {
   background-color: #d3d3d3;
   cursor: pointer;

--- a/extension/settings/settings.css
+++ b/extension/settings/settings.css
@@ -28,6 +28,10 @@ td {
   max-height: 10px;
 }
 
+.alertPreWrap {
+  white-space: pre-wrap;
+}
+
 .content {
   padding-left: 12em;
   width: 40em;

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -447,6 +447,9 @@ export const getSearchResults = (
   exp: Expression['expression'],
   input: string,
 ): boolean => {
+  if (input.endsWith('\\')) {
+    return false;
+  }
   const ixp1 = globExpressionToRegExp(input).slice(0, -1).toLowerCase();
   const exp1 = exp.toLowerCase();
   const exp2 = exp1.slice(exp1.startsWith('*.') ? 2 : 0);
@@ -460,7 +463,7 @@ export const getSearchResults = (
     exp2.startsWith(ixp1) ||
     exp1.endsWith(ixp1) ||
     exp1.endsWith(input) ||
-    exp1.includes(input)
+    exp1.includes(ixp1)
   );
 };
 

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -865,3 +865,35 @@ export const undefinedIsTrue = (bool: boolean | undefined): boolean => {
   if (bool === undefined) return true;
   return bool;
 };
+
+/**
+ * Validate a single Expression.
+ * Returns undefined if valid.  Otherwise returns an error message.
+ * @param input The Domain Expression to validate.
+ */
+export const validateExpressionDomain = (input: string): string => {
+  const inputTrim = input.trim();
+  if (!inputTrim) return browser.i18n.getMessage('inputErrorEmpty');
+  if (inputTrim.startsWith('/') && inputTrim.endsWith('/')) {
+    // Regular Expression
+    try {
+      new RegExp(inputTrim.slice(1, -1));
+    } catch (e) {
+      return browser.i18n.getMessage('inputErrorRegExp', [`${e}`]);
+    }
+  } else if (inputTrim.startsWith('/')) {
+    // missing end slash.
+    return browser.i18n.getMessage('inputErrorSlashStartMissingEnd');
+  } else if (inputTrim.endsWith('/')) {
+    // missing beginning slash, or not regex
+    return browser.i18n.getMessage('inputErrorEndSlashMissingStart');
+  } else if (inputTrim.indexOf(',') !== -1) {
+    // no commas allowed in non-regex
+    return browser.i18n.getMessage('inputErrorComma');
+  }
+  if (inputTrim.indexOf(' ') !== -1) {
+    // no spaces allowed in hostnames or RegExp.
+    return browser.i18n.getMessage('inputErrorSpace');
+  }
+  return '';
+};

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -459,7 +459,8 @@ export const getSearchResults = (
     exp2.startsWith(input) ||
     exp2.startsWith(ixp1) ||
     exp1.endsWith(ixp1) ||
-    exp1.endsWith(input)
+    exp1.endsWith(input) ||
+    exp1.includes(input)
   );
 };
 

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -881,15 +881,20 @@ export const validateExpressionDomain = (input: string): string => {
     } catch (e) {
       return browser.i18n.getMessage('inputErrorRegExp', [`${e}`]);
     }
-  } else if (inputTrim.startsWith('/')) {
-    // missing end slash.
-    return browser.i18n.getMessage('inputErrorSlashStartMissingEnd');
-  } else if (inputTrim.endsWith('/')) {
-    // missing beginning slash, or not regex
-    return browser.i18n.getMessage('inputErrorEndSlashMissingStart');
-  } else if (inputTrim.indexOf(',') !== -1) {
-    // no commas allowed in non-regex
-    return browser.i18n.getMessage('inputErrorComma');
+  } else {
+    // not Regex
+    if (inputTrim.startsWith('/')) {
+      // missing end slash.
+      return browser.i18n.getMessage('inputErrorSlashStartMissingEnd');
+    }
+    if (inputTrim.endsWith('/')) {
+      // missing beginning slash, or not regex
+      return browser.i18n.getMessage('inputErrorSlashEndMissingStart');
+    }
+    if (inputTrim.indexOf(',') !== -1) {
+      // no commas allowed in non-regex
+      return browser.i18n.getMessage('inputErrorComma');
+    }
   }
   if (inputTrim.indexOf(' ') !== -1) {
     // no spaces allowed in hostnames or RegExp.

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -447,24 +447,25 @@ export const getSearchResults = (
   exp: Expression['expression'],
   input: string,
 ): boolean => {
-  if (input.endsWith('\\')) {
+  try {
+    const ixp1 = globExpressionToRegExp(input).slice(0, -1).toLowerCase();
+    const exp1 = exp.toLowerCase();
+    const exp2 = exp1.slice(exp1.startsWith('*.') ? 2 : 0);
+    return (
+      new RegExp(globExpressionToRegExp(exp), 'i').test(input) ||
+      new RegExp(globExpressionToRegExp(input), 'i').test(exp) ||
+      new RegExp(ixp1, 'i').test(exp) ||
+      exp1.startsWith(ixp1) ||
+      exp1.startsWith(input) ||
+      exp2.startsWith(input) ||
+      exp2.startsWith(ixp1) ||
+      exp1.endsWith(ixp1) ||
+      exp1.endsWith(input) ||
+      exp1.includes(ixp1)
+    );
+  } catch (e) {
     return false;
   }
-  const ixp1 = globExpressionToRegExp(input).slice(0, -1).toLowerCase();
-  const exp1 = exp.toLowerCase();
-  const exp2 = exp1.slice(exp1.startsWith('*.') ? 2 : 0);
-  return (
-    new RegExp(globExpressionToRegExp(exp), 'i').test(input) ||
-    new RegExp(globExpressionToRegExp(input), 'i').test(exp) ||
-    new RegExp(ixp1, 'i').test(exp) ||
-    exp1.startsWith(ixp1) ||
-    exp1.startsWith(input) ||
-    exp2.startsWith(input) ||
-    exp2.startsWith(ixp1) ||
-    exp1.endsWith(ixp1) ||
-    exp1.endsWith(input) ||
-    exp1.includes(ixp1)
-  );
 };
 
 /**

--- a/src/ui/common_components/ErrorBoundary.tsx
+++ b/src/ui/common_components/ErrorBoundary.tsx
@@ -70,7 +70,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
     if (this.state.hasError) {
       // You can render any custom fallback UI
       return (
-        <div className="alert alert-danger" role="alert">
+        <div className="alert alert-danger alertPreWrap" role="alert">
           <h4 className="alert-heading">
             {browser.i18n.getMessage('errorText')}
           </h4>

--- a/src/ui/common_components/ExpressionTable.tsx
+++ b/src/ui/common_components/ExpressionTable.tsx
@@ -147,7 +147,7 @@ class ExpressionTable extends React.Component<
       expressionColumnTitle,
       emptyElement,
     } = this.props;
-    const { editMode, id, expressionInput, invalid } = this.state;
+    const { editMode, id, invalid } = this.state;
     const expressions =
       this.props.expressions === undefined ? [] : this.props.expressions;
 
@@ -182,86 +182,82 @@ class ExpressionTable extends React.Component<
                   }}
                 />
               </td>
-              {editMode && id === expression.id ? (
-                <td className="editableExpression">
-                  <input
-                    ref={(c) => {
-                      this.editInput = c;
-                    }}
-                    className="form-control"
-                    value={expressionInput}
-                    onFocus={this.moveCaretToEnd}
-                    onChange={(e) =>
-                      this.setState({
-                        expressionInput: e.target.value,
-                      })
-                    }
-                    onKeyUp={(e) => {
-                      if (e.key.toLowerCase().includes('enter')) {
-                        this.commitEdit();
-                      }
-                    }}
-                    type="url"
-                    autoFocus={true}
-                    style={{
-                      display: 'inline-block',
-                      margin: 0,
-                      verticalAlign: 'middle',
-                    }}
-                    formNoValidate={true}
-                  />
-                  <div className="invalid-feedback">{invalid}</div>
-                  <IconButton
-                    title={browser.i18n.getMessage('stopEditingText')}
-                    className="btn-outline-danger"
-                    iconName="ban"
-                    styleReact={{
-                      float: 'left',
-                      marginTop: '8px',
-                      width: '45%',
-                    }}
-                    onClick={() => {
-                      this.clearEdit();
-                    }}
-                  />
-                  <IconButton
-                    title={browser.i18n.getMessage('saveExpressionText')}
-                    className="btn-outline-success"
-                    iconName="save"
-                    styleReact={{
-                      float: 'right',
-                      marginTop: '8px',
-                      width: '45%',
-                    }}
-                    onClick={() => {
+              <td className="editableExpression">
+                <input
+                  ref={(c) => {
+                    this.editInput = c;
+                  }}
+                  className="form-control"
+                  value={expression.expression}
+                  onFocus={this.moveCaretToEnd}
+                  onChange={(e) =>
+                    this.setState({
+                      expressionInput: e.target.value,
+                    })
+                  }
+                  onKeyUp={(e) => {
+                    if (e.key.toLowerCase().includes('enter')) {
                       this.commitEdit();
-                    }}
-                  />
-                </td>
-              ) : (
-                <td>
-                  <div
-                    style={{
-                      display: 'inline-block',
-                      verticalAlign: 'middle',
-                    }}
-                  >
-                    {`${expression.expression}`}
+                    }
+                  }}
+                  type="url"
+                  autoFocus={!(editMode && id === expression.id)}
+                  style={{
+                    display: 'inline-block',
+                    margin: 0,
+                    verticalAlign: 'middle',
+                  }}
+                  formNoValidate={true}
+                  disabled={!(editMode && id === expression.id)}
+                  aria-disabled={!(editMode && id === expression.id)}
+                />
+                <div className="invalid-feedback">{invalid}</div>
+                {editMode && id === expression.id ? (
+                  <div>
+                    <IconButton
+                      title={browser.i18n.getMessage('stopEditingText')}
+                      className="btn-outline-danger"
+                      iconName="ban"
+                      styleReact={{
+                        float: 'left',
+                        marginTop: '8px',
+                        width: '45%',
+                      }}
+                      onClick={() => {
+                        this.clearEdit();
+                      }}
+                    />
+                    <IconButton
+                      title={browser.i18n.getMessage('saveExpressionText')}
+                      className="btn-outline-success"
+                      iconName="save"
+                      styleReact={{
+                        float: 'right',
+                        marginTop: '8px',
+                        width: '45%',
+                      }}
+                      onClick={() => {
+                        this.commitEdit();
+                      }}
+                    />
                   </div>
-                  <IconButton
-                    title={browser.i18n.getMessage('editExpressionText')}
-                    iconName="pen"
-                    className="btn-outline-info showOnRowHover"
-                    styleReact={{
-                      float: 'right',
-                      marginLeft: '5px',
-                    }}
-                    onClick={() => {
-                      this.startEditing(expression);
-                    }}
-                  />
-                </td>
-              )}
+                ) : (
+                  <div>
+                    <IconButton
+                      title={browser.i18n.getMessage('editExpressionText')}
+                      iconName="pen"
+                      className="btn-outline-info showOnRowHover"
+                      styleReact={{
+                        marginTop: '8px',
+                        width: '100%',
+                      }}
+                      onClick={() => {
+                        this.startEditing(expression);
+                      }}
+                    />
+                  </div>
+                )}
+              </td>
               <td>
                 <div
                   style={{

--- a/src/ui/common_components/ExpressionTable.tsx
+++ b/src/ui/common_components/ExpressionTable.tsx
@@ -114,7 +114,7 @@ class ExpressionTable extends React.Component<
         new RegExp(inputTrim.slice(1, -1));
       } catch (e) {
         return this.setInvalid(
-          browser.i18n.getMessage('inputErrorComma', [`${e}`]),
+          browser.i18n.getMessage('inputErrorRegExp', [`${e}`]),
         );
       }
     } else if (inputTrim.startsWith('/')) {
@@ -208,6 +208,7 @@ class ExpressionTable extends React.Component<
                       margin: 0,
                       verticalAlign: 'middle',
                     }}
+                    formNoValidate={true}
                   />
                   <div className="invalid-feedback">{invalid}</div>
                   <IconButton

--- a/src/ui/common_components/ExpressionTable.tsx
+++ b/src/ui/common_components/ExpressionTable.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { removeExpressionUI, updateExpressionUI } from '../../redux/Actions';
+import { validateExpressionDomain } from '../../services/Libs';
 import { ReduxAction } from '../../typings/ReduxConstants';
 import ExpressionOptions from './ExpressionOptions';
 import IconButton from './IconButton';
@@ -104,32 +105,12 @@ class ExpressionTable extends React.Component<
 
   public validateEdit(): boolean {
     if (!this.state.editMode || !this.editInput || !this.state.id) return false;
-    const inputTrim = this.state.expressionInput.trim();
-    if (!inputTrim) {
-      return this.setInvalid(browser.i18n.getMessage('inputErrorEmpty'));
-    }
-    if (inputTrim.startsWith('/') && inputTrim.endsWith('/')) {
-      // Regular Expression
-      try {
-        new RegExp(inputTrim.slice(1, -1));
-      } catch (e) {
-        return this.setInvalid(
-          browser.i18n.getMessage('inputErrorRegExp', [`${e}`]),
-        );
-      }
-    } else if (inputTrim.startsWith('/')) {
-      // missing end slash.
-      return this.setInvalid(
-        browser.i18n.getMessage('inputErrorSlashStartMissingEnd'),
-      );
-    } else if (inputTrim.endsWith('/')) {
-      // missing beginning slash, or not regex
-      return this.setInvalid(
-        browser.i18n.getMessage('inputErrorSlashEndMissingStart'),
-      );
-    } else if (inputTrim.indexOf(',') !== -1) {
-      // no commas allowed in non-regex
-      return this.setInvalid(browser.i18n.getMessage('inputErrorComma'));
+    const result = validateExpressionDomain(
+      this.state.expressionInput.trim(),
+    ).trim();
+    if (result) {
+      // validation failed.
+      return this.setInvalid(result);
     }
     // Past this point, presume valid expression entry.
     this.editInput.setCustomValidity('');
@@ -208,6 +189,7 @@ class ExpressionTable extends React.Component<
                     style={{
                       margin: 0,
                     }}
+                    formNoValidate={true}
                   />
                   <div className="invalid-feedback">{invalid}</div>
                   <IconButton

--- a/src/ui/common_components/ExpressionTable.tsx
+++ b/src/ui/common_components/ExpressionTable.tsx
@@ -147,7 +147,7 @@ class ExpressionTable extends React.Component<
       expressionColumnTitle,
       emptyElement,
     } = this.props;
-    const { editMode, id, invalid } = this.state;
+    const { editMode, id, expressionInput, invalid } = this.state;
     const expressions =
       this.props.expressions === undefined ? [] : this.props.expressions;
 
@@ -182,82 +182,85 @@ class ExpressionTable extends React.Component<
                   }}
                 />
               </td>
-              <td className="editableExpression">
-                <input
-                  ref={(c) => {
-                    this.editInput = c;
-                  }}
-                  className="form-control"
-                  value={expression.expression}
-                  onFocus={this.moveCaretToEnd}
-                  onChange={(e) =>
-                    this.setState({
-                      expressionInput: e.target.value,
-                    })
-                  }
-                  onKeyUp={(e) => {
-                    if (e.key.toLowerCase().includes('enter')) {
-                      this.commitEdit();
+              {editMode && id === expression.id ? (
+                <td className="editableExpression">
+                  <input
+                    ref={(c) => {
+                      this.editInput = c;
+                    }}
+                    className="form-control"
+                    value={expressionInput}
+                    onFocus={this.moveCaretToEnd}
+                    onChange={(e) =>
+                      this.setState({
+                        expressionInput: e.target.value,
+                      })
                     }
-                  }}
-                  type="url"
-                  autoFocus={!(editMode && id === expression.id)}
-                  style={{
-                    display: 'inline-block',
-                    margin: 0,
-                    verticalAlign: 'middle',
-                  }}
-                  formNoValidate={true}
-                  disabled={!(editMode && id === expression.id)}
-                  aria-disabled={!(editMode && id === expression.id)}
-                />
-                <div className="invalid-feedback">{invalid}</div>
-                {editMode && id === expression.id ? (
-                  <div>
-                    <IconButton
-                      title={browser.i18n.getMessage('stopEditingText')}
-                      className="btn-outline-danger"
-                      iconName="ban"
-                      styleReact={{
-                        float: 'left',
-                        marginTop: '8px',
-                        width: '45%',
-                      }}
-                      onClick={() => {
-                        this.clearEdit();
-                      }}
-                    />
-                    <IconButton
-                      title={browser.i18n.getMessage('saveExpressionText')}
-                      className="btn-outline-success"
-                      iconName="save"
-                      styleReact={{
-                        float: 'right',
-                        marginTop: '8px',
-                        width: '45%',
-                      }}
-                      onClick={() => {
+                    onKeyUp={(e) => {
+                      if (e.key.toLowerCase().includes('enter')) {
                         this.commitEdit();
-                      }}
-                    />
+                      }
+                    }}
+                    type="url"
+                    autoFocus={true}
+                    style={{
+                      display: 'inline-block',
+                      margin: 0,
+                      verticalAlign: 'middle',
+                    }}
+                  />
+                  <div className="invalid-feedback">{invalid}</div>
+                  <IconButton
+                    title={browser.i18n.getMessage('stopEditingText')}
+                    className="btn-outline-danger"
+                    iconName="ban"
+                    styleReact={{
+                      float: 'left',
+                      marginTop: '8px',
+                      width: '45%',
+                    }}
+                    onClick={() => {
+                      this.clearEdit();
+                    }}
+                  />
+                  <IconButton
+                    title={browser.i18n.getMessage('saveExpressionText')}
+                    className="btn-outline-success"
+                    iconName="save"
+                    styleReact={{
+                      float: 'right',
+                      marginTop: '8px',
+                      width: '45%',
+                    }}
+                    onClick={() => {
+                      this.commitEdit();
+                    }}
+                  />
+                </td>
+              ) : (
+                <td>
+                  <div
+                    style={{
+                      display: 'inline-block',
+                      verticalAlign: 'middle',
+                    }}
+                  >
+                    {`${expression.expression}`}
                   </div>
-                ) : (
-                  <div>
-                    <IconButton
-                      title={browser.i18n.getMessage('editExpressionText')}
-                      iconName="pen"
-                      className="btn-outline-info showOnRowHover"
-                      styleReact={{
-                        marginTop: '8px',
-                        width: '100%',
-                      }}
-                      onClick={() => {
-                        this.startEditing(expression);
-                      }}
-                    />
-                  </div>
-                )}
-              </td>
+                  <IconButton
+                    title={browser.i18n.getMessage('editExpressionText')}
+                    iconName="pen"
+                    className="btn-outline-info showOnRowHover"
+                    styleReact={{
+                      float: 'right',
+                      marginLeft: '5px',
+                    }}
+                    onClick={() => {
+                      this.startEditing(expression);
+                    }}
+                  />
+                </td>
+              )}
               <td>
                 <div
                   style={{

--- a/src/ui/common_components/ExpressionTable.tsx
+++ b/src/ui/common_components/ExpressionTable.tsx
@@ -156,13 +156,13 @@ class ExpressionTable extends React.Component<
     }
 
     return (
-      <table className={'table table-striped table-hover table-bordered'}>
+      <table className="table table-striped table-hover table-bordered">
         <thead>
           <tr>
-            <th />
-            <th>{expressionColumnTitle}</th>
-            <th>{browser.i18n.getMessage('optionsText')}</th>
-            <th>{browser.i18n.getMessage('listTypeText')}</th>
+            <th scope="col" />
+            <th scope="col">{expressionColumnTitle}</th>
+            <th scope="col">{browser.i18n.getMessage('optionsText')}</th>
+            <th scope="col">{browser.i18n.getMessage('listTypeText')}</th>
           </tr>
         </thead>
         <tbody className="expressionTable">
@@ -199,14 +199,14 @@ class ExpressionTable extends React.Component<
                     onKeyUp={(e) => {
                       if (e.key.toLowerCase().includes('enter')) {
                         this.commitEdit();
+                      } else if (e.key.toLowerCase().includes('escape')) {
+                        this.clearEdit();
                       }
                     }}
                     type="url"
                     autoFocus={true}
                     style={{
-                      display: 'inline-block',
                       margin: 0,
-                      verticalAlign: 'middle',
                     }}
                   />
                   <div className="invalid-feedback">{invalid}</div>
@@ -239,21 +239,29 @@ class ExpressionTable extends React.Component<
                 </td>
               ) : (
                 <td>
-                  <div
+                  <textarea
+                    className="form-control form-control-plaintext"
+                    readOnly={true}
+                    rows={1}
                     style={{
-                      display: 'inline-block',
-                      verticalAlign: 'middle',
+                      margin: 0,
+                      overflowX: 'scroll',
+                      paddingLeft: '5px',
+                      paddingRight: '5px',
+                      resize: 'none',
+                      whiteSpace: 'nowrap',
                     }}
                   >
-                    {`${expression.expression}`}
-                  </div>
+                    {expression.expression}
+                  </textarea>
+
                   <IconButton
                     title={browser.i18n.getMessage('editExpressionText')}
                     iconName="pen"
                     className="btn-outline-info showOnRowHover"
                     styleReact={{
-                      float: 'right',
-                      marginLeft: '5px',
+                      marginTop: '5px',
+                      width: '100%',
                     }}
                     onClick={() => {
                       this.startEditing(expression);
@@ -273,7 +281,7 @@ class ExpressionTable extends React.Component<
               <td>
                 <div
                   style={{
-                    display: 'inline-block',
+                    display: 'block',
                     verticalAlign: 'middle',
                   }}
                 >
@@ -292,8 +300,8 @@ class ExpressionTable extends React.Component<
                   iconName="exchange-alt"
                   className="btn-outline-dark showOnRowHover"
                   styleReact={{
-                    float: 'right',
-                    marginLeft: '5px',
+                    marginTop: '5px',
+                    width: '100%',
                   }}
                   onClick={() =>
                     onUpdateExpression({

--- a/src/ui/settings/components/Expressions.tsx
+++ b/src/ui/settings/components/Expressions.tsx
@@ -338,8 +338,8 @@ class Expressions extends React.Component<ExpressionProps> {
               })
             }
             placeholder={browser.i18n.getMessage('domainPlaceholderText')}
-            onKeyPress={(e) => {
-              if (e.key === 'Enter') {
+            onKeyUp={(e) => {
+              if (e.key.toLowerCase() === 'enter') {
                 this.addExpressionByInput({
                   expression: this.state.expressionInput,
                   listType: e.shiftKey ? ListType.GREY : ListType.WHITE,

--- a/src/ui/settings/components/Expressions.tsx
+++ b/src/ui/settings/components/Expressions.tsx
@@ -173,7 +173,7 @@ class Expressions extends React.Component<ExpressionProps> {
         inputReasons.push(`- ${expTrim} -> ${result}`);
       } else {
         // valid
-        validInputs.push(expTrim);
+        validInputs.push(`- ${expTrim}`);
         onNewExpression({
           ...payload,
           expression: expTrim,

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -264,7 +264,7 @@ class Settings extends React.Component<SettingProps> {
         {error !== '' ? (
           <div
             onClick={() => this.setState({ error: '' })}
-            className="row alert alert-danger"
+            className="row alert alert-danger alertPreWrap"
           >
             {error}
           </div>
@@ -274,7 +274,7 @@ class Settings extends React.Component<SettingProps> {
         {success !== '' ? (
           <div
             onClick={() => this.setState({ success: '' })}
-            className="row alert alert-success"
+            className="row alert alert-success alertPreWrap"
           >
             {browser.i18n.getMessage('successText')} {success}
           </div>

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -83,9 +83,9 @@ class Settings extends React.Component<SettingProps> {
     if (importFile.type !== 'application/json') {
       this.setError(
         new Error(
-          `${browser.i18n.getMessage('errorText')} ${browser.i18n.getMessage(
-            'importFileTypeInvalid',
-          )}:  ${importFile.name} (${importFile.type})`,
+          `${browser.i18n.getMessage('importFileTypeInvalid')}:  ${
+            importFile.name
+          } (${importFile.type})`,
         ),
       );
       return;
@@ -96,7 +96,11 @@ class Settings extends React.Component<SettingProps> {
     reader.onload = (file) => {
       try {
         if (!file.target) {
-          this.setError(new Error('File Not Found!'));
+          this.setError(
+            new Error(
+              browser.i18n.getMessage('importFileNotFound', [importFile.name]),
+            ),
+          );
           return;
         }
         // https://stackoverflow.com/questions/35789498/new-typescript-1-8-4-build-error-build-property-result-does-not-exist-on-t


### PR DESCRIPTION
This adds validation for editing existing expressions on the Expression Table.  Resolves #849.

Note:  This is only when editing expressions, NOT applied (yet) to adding new expressions.

This only covers the more common items such as:
- Validating Regex
- Checking for Start AND End Slash for Regex
- If not Regex:
  - slash is found at beginning or end.
  - comma is found (only allowed in Regex)

If there are other validations I should do please let me know.

This also moves the reset/save buttons to the bottom of the input field and makes them larger.

![image](https://user-images.githubusercontent.com/6724477/97068099-51a62080-1579-11eb-86ad-87ef1243c6b5.png)

![image](https://user-images.githubusercontent.com/6724477/97068175-3b4c9480-157a-11eb-8bfc-8d38710769b6.png)

Since the first commit, the following items have been added/adjusted:
- Wrapping Long expression domains through textarea to almost mimic the size of the input field.  Resolves #850.
- Shift+Enter to add to GreyList on active list.
- Validate New Expressions from manual input as well as from file import.
- Fixed crash when having a `\` at the end of a search string.

![Peek 2020-10-26 22-45](https://user-images.githubusercontent.com/6724477/97264216-c2e80c80-17e1-11eb-9abf-efe75e6b8e4b.gif)


Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>