### PR TITLE
Add debug info to about page for easier copy-paste to GitHub.

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -191,6 +191,26 @@
     "message": "Run cleanup now, exclude domains from open tabs",
     "description": "Run cleanup now, exclude domains from open tabs. This is shown on mouseover on the button."
   },
+  "copyDebugSettingText": {
+    "message": "Your current settings.  If necessary, copy and paste this into the GitHub Issue.",
+    "description": "Your current settings.  If necessary, copy and paste this into the GitHub Issue."
+  },
+  "copyDebugSystemText": {
+    "message": "Your System Info.  Copy and paste into the relevant section of the GitHub Issue.",
+    "description": "Your System Info.  Copy and paste into the relevant section of the GitHub Issue."
+  },
+  "copyFailedText": {
+    "message": "Copy failed.  Try manually selecting and copying the text.",
+    "description": "Copy failed.  Try manually selecting and copying the text.  Shown after a failed attempt to write text to clipboard."
+  },
+  "copySuccessText": {
+    "message": "Copied successfully!",
+    "description": "Copied successfully!  Shows after a successful text copy to clipboard."
+  },
+  "copyToClipboardText": {
+    "message": "Copy to Clipboard",
+    "description": "Copy to Clipboard.  Shown in a button to take action upon click."
+  },
   "createDefaultExpressionOptionsText": {
     "message": "Create Default Expression Options",
     "description": "Create Default Expression Options. Used in 'List of Expressions'"
@@ -212,6 +232,10 @@
   "debugMode": {
     "message": "Enable Debug Mode (Additional Console Outputs)",
     "description": "Enable Debug Mode (Additional Console Outputs). Found in CAD Settings."
+  },
+  "debugTitle": {
+    "message": "Debug Information",
+    "description": "Debug Information.  Header shown on About page."
   },
   "defaultText": {
     "message": "Default",
@@ -314,7 +338,7 @@
     "description": "Looking to set default expression options for new expressions?  It has been enhanced to be an expression option itself!  Visit $listExpression$ to get started!  Shown in Settings",
     "placeholders": {
       "listExpression": {
-        "content":"$1",
+        "content": "$1",
         "example": "List of Expressions <- the translated version"
       }
     }
@@ -352,7 +376,7 @@
   "importListNotArray": {
     "message": "$identifier$ is not formatted as an array list.",
     "description": "$identifier$ is not formatted as an array list.  Found in List of Expressions during import validation.",
-    "placeholders":{
+    "placeholders": {
       "identifier": {
         "content": "$1",
         "example": "jsonObjectKey"

--- a/src/background.ts
+++ b/src/background.ts
@@ -81,6 +81,13 @@ const onStartUp = async () => {
       },
       type: ReduxConstants.ADD_CACHE,
     });
+    store.dispatch({
+      payload: {
+        key: 'browserInfo',
+        value: browserInfo,
+      },
+      type: ReduxConstants.ADD_CACHE,
+    });
   }
   // Store which browser environment in cache
   store.dispatch({
@@ -93,6 +100,13 @@ const onStartUp = async () => {
 
   // Store platform in cache
   const platformInfo = await browser.runtime.getPlatformInfo();
+  store.dispatch({
+    payload: {
+      key: 'platformInfo',
+      value: platformInfo,
+    },
+    type: ReduxConstants.ADD_CACHE,
+  });
   store.dispatch({
     payload: {
       key: 'platformOs',

--- a/src/ui/font-awesome-imports.tsx
+++ b/src/ui/font-awesome-imports.tsx
@@ -10,6 +10,7 @@ import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
 import { faBell } from '@fortawesome/free-solid-svg-icons/faBell';
 import { faBellSlash } from '@fortawesome/free-solid-svg-icons/faBellSlash';
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog';
+import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload';
 import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons/faExchangeAlt';
@@ -33,6 +34,7 @@ export default (): void => {
     faBell,
     faBellSlash,
     faCog,
+    faCopy,
     faDownload,
     faEraser,
     faExchangeAlt,

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -11,84 +11,287 @@
  * SOFTWARE.
  */
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { cadLog, isFirefox } from '../../../services/Libs';
+import IconButton from '../../common_components/IconButton';
+
+const styles = {
+  buttonStyle: {
+    height: 'max-content',
+    padding: '0.75em',
+    width: 'max-content',
+  },
+};
 interface OwnProps {
   style?: React.CSSProperties;
 }
-const About: React.FunctionComponent<OwnProps> = (props) => {
-  const { style } = props;
-  return (
-    <div style={style}>
-      <h1>{browser.i18n.getMessage('aboutText')}</h1>
-      <h5>
-        {browser.i18n.getMessage('versionNumberText', ['CAD'])}:
+
+interface StateProps {
+  bName: browserName;
+  cache: CacheMap;
+  platformInfo: browser.runtime.PlatformInfo;
+  settings: MapToSettingObject;
+}
+enum platformOS {
+  mac = 'Mac OS',
+  win = 'Windows',
+  android = 'Android',
+  cros = 'Chrome OS',
+  linux = 'Linux',
+  openbsd = 'Open/FreeBSD',
+}
+
+const settingOrder = [
+  SettingID.ACTIVE_MODE,
+  SettingID.CLEAN_DELAY,
+  SettingID.CLEAN_DISCARDED,
+  SettingID.CLEAN_DOMAIN_CHANGE,
+  SettingID.ENABLE_GREYLIST,
+  SettingID.CLEAN_OPEN_TABS_STARTUP,
+  SettingID.CLEAN_EXPIRED,
+  SettingID.CLEANUP_CACHE,
+  SettingID.CLEANUP_INDEXEDDB,
+  SettingID.CLEANUP_LOCALSTORAGE,
+  SettingID.CLEANUP_PLUGIN_DATA,
+  SettingID.CLEANUP_SERVICE_WORKERS,
+  SettingID.CONTEXTUAL_IDENTITIES,
+  SettingID.CONTEXTUAL_IDENTITIES_AUTOREMOVE,
+  SettingID.STAT_LOGGING,
+  SettingID.NUM_COOKIES_ICON,
+  SettingID.KEEP_DEFAULT_ICON,
+  SettingID.NOTIFY_AUTO,
+  SettingID.NOTIFY_MANUAL,
+  SettingID.NOTIFY_DURATION,
+  SettingID.ENABLE_NEW_POPUP,
+  SettingID.SIZE_POPUP,
+  SettingID.SIZE_SETTING,
+  SettingID.CONTEXT_MENUS,
+  SettingID.DEBUG_MODE,
+];
+
+type AboutProps = OwnProps & StateProps;
+
+class About extends React.Component<AboutProps> {
+  public render() {
+    const { bName, cache, platformInfo, settings, style } = this.props;
+    const settingSlim = settingOrder.map((s) => {
+      const so = settings[s];
+      return `- ${so.name}: ${so.value}`;
+    });
+    return (
+      <div style={style}>
+        <h1>{browser.i18n.getMessage('aboutText')}</h1>
+        <h5>
+          {browser.i18n.getMessage('versionNumberText', ['CAD'])}:
+          <br />
+          <b>{browser.runtime.getManifest().version}</b>
+        </h5>
+        <a href="https://github.com/mrdokenny/Cookie-AutoDelete/issues">
+          {browser.i18n.getMessage('reportIssuesText')}
+        </a>{' '}
         <br />
-        <b>{browser.runtime.getManifest().version}</b>
-      </h5>
-      <a href="https://github.com/mrdokenny/Cookie-AutoDelete/issues">
-        {browser.i18n.getMessage('reportIssuesText')}
-      </a>{' '}
-      <br />
-      <br />
-      <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/Documentation">
-        <span>{`${browser.i18n.getMessage('documentationText')}`}</span>
-      </a>
-      <br />
-      <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/FAQ:-Common-Questions-and-Issues">
-        <span>{`${browser.i18n.getMessage('faqText')}`}</span>
-      </a>
-      <br />
-      <br />{' '}
-      <a
-        href="https://chrome.google.com/webstore/detail/cookie-autodelete/fhcgjolkccmbidfldomjliifgaodjagh"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <span>{`${browser.i18n.getMessage('versionText', [
-          'Google Chrome',
-        ])}`}</span>{' '}
-      </a>
-      <br />
-      <a
-        href="https://microsoftedge.microsoft.com/addons/detail/djkjpnciiommncecmdefpdllknjdmmmo"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <span>{`${browser.i18n.getMessage('versionText', [
-          'Microsoft Edge Chromium',
-        ])}`}</span>{' '}
-      </a>{' '}
-      <br />
-      <a
-        href="https://addons.mozilla.org/firefox/addon/cookie-autodelete/"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <span>{`${browser.i18n.getMessage('versionText', [
-          'Mozilla Firefox',
-        ])}`}</span>{' '}
-      </a>{' '}
-      <br />
-      <br />
-      <span>{`${browser.i18n.getMessage('contributorsText')}`}:</span>
-      <ul>
-        <li>Kenny Do (Creator)</li>
-        <li>
-          seansfkelley (UI Redesign of Expression Table Settings and Popup)
-        </li>
-        <li>kennethtran93 (UI bug fixes and then some)</li>
-        <li>
-          <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors">
-            GitHub Contributors
-          </a>
-        </li>
-        <li>
-          <a href="https://crowdin.com/project/cookie-autodelete">
-            Crowdin Contributors
-          </a>
-        </li>
-      </ul>
-    </div>
-  );
+        <br />
+        <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/Documentation">
+          <span>{`${browser.i18n.getMessage('documentationText')}`}</span>
+        </a>
+        <br />
+        <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/FAQ:-Common-Questions-and-Issues">
+          <span>{`${browser.i18n.getMessage('faqText')}`}</span>
+        </a>
+        <br />
+        <br />{' '}
+        <a
+          href="https://chrome.google.com/webstore/detail/cookie-autodelete/fhcgjolkccmbidfldomjliifgaodjagh"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span>{`${browser.i18n.getMessage('versionText', [
+            'Google Chrome',
+          ])}`}</span>{' '}
+        </a>
+        <br />
+        <a
+          href="https://microsoftedge.microsoft.com/addons/detail/djkjpnciiommncecmdefpdllknjdmmmo"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span>{`${browser.i18n.getMessage('versionText', [
+            'Microsoft Edge Chromium',
+          ])}`}</span>{' '}
+        </a>{' '}
+        <br />
+        <a
+          href="https://addons.mozilla.org/firefox/addon/cookie-autodelete/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span>{`${browser.i18n.getMessage('versionText', [
+            'Mozilla Firefox',
+          ])}`}</span>{' '}
+        </a>{' '}
+        <br />
+        <br />
+        <span>{`${browser.i18n.getMessage('contributorsText')}`}:</span>
+        <ul>
+          <li>Kenny Do (Creator)</li>
+          <li>
+            seansfkelley (UI Redesign of Expression Table Settings and Popup)
+          </li>
+          <li>kennethtran93 (UI bug fixes and then some)</li>
+          <li>
+            <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors">
+              GitHub Contributors
+            </a>
+          </li>
+          <li>
+            <a href="https://crowdin.com/project/cookie-autodelete">
+              Crowdin Contributors
+            </a>
+          </li>
+        </ul>
+        <br />
+        <h3>{browser.i18n.getMessage('debugTitle')}</h3>
+        <p>{browser.i18n.getMessage('copyDebugSystemText')}</p>
+        <textarea
+          id="debugInfo"
+          rows={3}
+          cols={40}
+          readOnly={true}
+          style={{ resize: 'none' }}
+        >
+          {`- OS: ${platformInfo.arch} ${
+            platformOS[platformInfo.os]
+          } (Please add OS version on paste)\n- Browser Info: ${bName} ${
+            isFirefox(cache)
+              ? `${cache.browserVersion} (${cache.browserInfo.buildID})`
+              : `(Please add version number on paste)`
+          }\n- CookieAutoDelete Version: ${
+            browser.runtime.getManifest().version
+          }`}
+        </textarea>
+        <br />
+        <IconButton
+          className="btn-primary"
+          role="button"
+          onClick={() => {
+            const textDebug = document.getElementById('debugInfo');
+            const spanCopy = document.getElementById('copy-debugInfo');
+            if (!textDebug || !spanCopy) {
+              cadLog(
+                {
+                  type: 'error',
+                  msg: 'Could not find either textarea or span for debugInfo',
+                },
+                true,
+              );
+              return;
+            }
+            if (!textDebug.textContent) {
+              cadLog(
+                {
+                  type: 'error',
+                  msg: 'Could not get textContent from textarea for debugInfo',
+                },
+                true,
+              );
+              return;
+            }
+            navigator.clipboard.writeText(textDebug.textContent).then(
+              () => {
+                spanCopy.classList.add('text-success');
+                spanCopy.innerText = browser.i18n.getMessage('copySuccessText');
+              },
+              () => {
+                spanCopy.classList.add('text-danger');
+                spanCopy.innerText = browser.i18n.getMessage('copyFailedText');
+              },
+            );
+            setTimeout(() => {
+              spanCopy.innerText = '';
+              spanCopy.classList.remove('text-danger', 'text-success');
+            }, 5000);
+          }}
+          iconName="copy"
+          title={browser.i18n.getMessage('copyToClipboardText')}
+          text={browser.i18n.getMessage('copyToClipboardText')}
+          styleReact={styles.buttonStyle}
+        />{' '}
+        <span id="copy-debugInfo">&nbsp;</span>
+        <br />
+        <br />
+        <p>{browser.i18n.getMessage('copyDebugSettingText')}</p>
+        <textarea
+          id="debugSettings"
+          rows={5}
+          cols={40}
+          readOnly={true}
+          style={{ resize: 'none' }}
+        >{`${settingSlim.join('\n')}`}</textarea>
+        <br />
+        <IconButton
+          className="btn-primary"
+          role="button"
+          onClick={() => {
+            const textDebug = document.getElementById('debugSettings');
+            const spanCopy = document.getElementById('copy-debugSettings');
+            if (!textDebug || !spanCopy) {
+              cadLog(
+                {
+                  type: 'error',
+                  msg:
+                    'Could not find either textarea or span for debugSettings',
+                },
+                true,
+              );
+              return;
+            }
+            if (!textDebug.textContent) {
+              cadLog(
+                {
+                  type: 'error',
+                  msg:
+                    'Could not get textContent from textarea for debugSettings',
+                },
+                true,
+              );
+              return;
+            }
+            navigator.clipboard.writeText(textDebug.textContent).then(
+              () => {
+                spanCopy.classList.add('text-success');
+                spanCopy.innerText = browser.i18n.getMessage('copySuccessText');
+              },
+              () => {
+                spanCopy.classList.add('text-danger');
+                spanCopy.innerText = browser.i18n.getMessage('copyFailedText');
+              },
+            );
+            setTimeout(() => {
+              spanCopy.innerText = '';
+              spanCopy.classList.remove('text-danger', 'text-success');
+            }, 5000);
+          }}
+          iconName="copy"
+          title={browser.i18n.getMessage('copyToClipboardText')}
+          text={browser.i18n.getMessage('copyToClipboardText')}
+          styleReact={styles.buttonStyle}
+        />{' '}
+        <span id="copy-debugSettings">&nbsp;</span>
+        <br />
+        <br />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state: State) => {
+  const { cache, settings } = state;
+  return {
+    bName: cache.browserDetect || (browserDetect() as browserName),
+    cache,
+    platformInfo: cache.platformInfo,
+    settings,
+  };
 };
 
-export default About;
+export default connect(mapStateToProps)(About);

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -86,7 +86,7 @@ class About extends React.Component<AboutProps> {
           <br />
           <b>{browser.runtime.getManifest().version}</b>
         </h5>
-        <a href="https://github.com/mrdokenny/Cookie-AutoDelete/issues">
+        <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/issues">
           {browser.i18n.getMessage('reportIssuesText')}
         </a>{' '}
         <br />


### PR DESCRIPTION
This adds a section under 'About' page with some of the debugging information, including OS, partial browser info, and the CAD version.  It should be formatted in a way that one can copy-paste it to GitHub.

A shorter version of the settings (in the order shown in settings) is also created for copy-paste.

![image](https://user-images.githubusercontent.com/6724477/110271759-7fff2800-7f7d-11eb-9c81-69220d7813f6.png)


One more item off the long-overdue checklist at #595.

Signed-off-by: Kenneth T <kennethtran93@users.noreply.github.com>