### PR TITLE
Fix stacked buttons when font size too small.  

### DIFF
--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -174,12 +174,11 @@ class App extends Component<PopupAppComponentProps, InitialState> {
         }}
       >
         <div
-          className="row"
+          className="row pt-2"
           style={{
             alignItems: 'center',
             backgroundColor: 'rgba(0, 0, 0, 0.05)',
             justifyContent: 'center',
-            paddingTop: '8px',
           }}
         >
           <span id="CADTitle">{browser.i18n.getMessage('extensionName')}</span>
@@ -189,21 +188,18 @@ class App extends Component<PopupAppComponentProps, InitialState> {
           </span>
         </div>
         <div
-          className="row justify-content-center"
+          className="row justify-content-center p-1"
           style={{
             alignItems: 'center',
             backgroundColor: 'rgba(0, 0, 0, 0.05)',
             borderBottom: '1px solid rgba(0, 0, 0, 0.1)',
-            padding: '4px 4px 8px 4px',
           }}
         >
           <IconButton
             iconName="power-off"
-            className={
-              settings[SettingID.ACTIVE_MODE].value
-                ? 'btn-success'
-                : 'btn-danger'
-            }
+            className={`btn-${
+              settings[SettingID.ACTIVE_MODE].value ? 'success' : 'danger'
+            } m-1`}
             onClick={() =>
               onUpdateSetting({
                 ...settings[SettingID.ACTIVE_MODE],
@@ -221,16 +217,13 @@ class App extends Component<PopupAppComponentProps, InitialState> {
                 : browser.i18n.getMessage('autoDeleteDisabledText')
             }
           />
-          <div className="w-100 py-1 d-sm-none"></div>
           <IconButton
             iconName={
               settings[SettingID.NOTIFY_AUTO].value ? 'bell' : 'bell-slash'
             }
-            className={
-              settings[SettingID.NOTIFY_AUTO].value
-                ? 'btn-success'
-                : 'btn-danger'
-            }
+            className={`btn-${
+              settings[SettingID.NOTIFY_AUTO].value ? 'success' : 'danger'
+            } m-1`}
             onClick={() =>
               onUpdateSetting({
                 ...settings[SettingID.NOTIFY_AUTO],
@@ -244,15 +237,11 @@ class App extends Component<PopupAppComponentProps, InitialState> {
                 : browser.i18n.getMessage('notificationDisabledText')
             }
           />
-          <div className="w-100 py-1 d-sm-none"></div>
           <div
             id="cleanButtonContainer"
-            className="btn-group"
+            className="btn-group m-1"
             role="group"
             aria-label="Clean Actions Group"
-            style={{
-              margin: '0 4px',
-            }}
           >
             <IconButton
               iconName="eraser"
@@ -290,10 +279,9 @@ class App extends Component<PopupAppComponentProps, InitialState> {
               </span>
             </button>
           </div>
-          <div className="w-100 py-1 d-sm-none"></div>
           <IconButton
             iconName="cog"
-            className="btn-info"
+            className="btn-info m-1"
             onClick={() => {
               if (isFirefoxNotAndroid(cache)) {
                 browser.tabs.create({

--- a/src/ui/popup/components/CleanDataButton.tsx
+++ b/src/ui/popup/components/CleanDataButton.tsx
@@ -70,7 +70,7 @@ const CleanDataButton: React.FunctionComponent<OwnProps & StateProps> = (
       aria-expanded="false"
       className={`btn ${
         btnColor || `btn-${altColor ? 'secondary' : 'primary'}`
-      } btn-block px-2`}
+      } btn-block px-2 mt-1`}
       data-target="#cleanCollapse"
       data-toggle="collapse"
       onClick={async () => {

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,13 @@
 {
   "releases": [
     {
+      "version": "unreleased",
+      "notes": [
+        "Enhanced:  Additional Clean options now have small amount of spacing between them.",
+        "Fixed:  Popup UI Buttons stacking when font size is small even though there is enough room for more than one button per row.  Now it should only stack when width is too small.  Fixes #1034."
+      ]
+    },
+    {
       "version": "3.6.0",
       "notes": [
         "Added:  Implementation of FireFox Containers/Contextual Identities.  This allows CAD to monitor when changes to containers info have been made, and remove the CAD list matching that removed container ID.",


### PR DESCRIPTION
As the 'popup within a popup which occasionally flickers' is no longer a thing, we can revert the forced stacking effect.  Closes #1034.

This also contains small optimizations to utilize bootstrap spacing classes in the popup.

