### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/tools/buildFilesDev.js
+++ b/tools/buildFilesDev.js
@@ -54,7 +54,7 @@ if (!versionTag) {
   );
 }
 
-const sha = process.env.GITSHA ? `_${process.env.GITSHA.substr(0, 7)}` : '';
+const sha = process.env.GITSHA ? `_${process.env.GITSHA.slice(0, 7)}` : '';
 
 const TAG =
   (versionTag ||


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.