### PR TITLE
Fix Firefox version check

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -73,7 +73,7 @@ const onStartUp = async () => {
   // Store the FF version in cache
   if (browserDetect() === browserName.Firefox) {
     const browserInfo = await browser.runtime.getBrowserInfo();
-    const browserVersion = browserInfo.version.split('.')[0];
+    const browserVersion = Number.parseInt(browserInfo.version);
     store.dispatch({
       payload: {
         key: 'browserVersion',

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -553,9 +553,10 @@ export const otherBrowsingDataCleanup = async (
   const chrome = isChrome(state.cache);
   const debug = getSetting(state, SettingID.DEBUG_MODE) as boolean;
   const browsingDataResult: ActivityLog['browsingDataCleanup'] = {};
+  const ffVersion = Number.parseInt(state.cache.browserVersion);
   if (
     getSetting(state, SettingID.CLEANUP_CACHE) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 78) ||
+    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 78) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.CACHE] = await cleanSiteData(
@@ -568,7 +569,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_INDEXEDDB) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 77) ||
+    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 77) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.INDEXEDDB] = await cleanSiteData(
@@ -581,7 +582,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_LOCALSTORAGE) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 58) ||
+    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 58) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.LOCALSTORAGE] = await cleanSiteData(
@@ -594,7 +595,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_PLUGIN_DATA) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 78) ||
+    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 78) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.PLUGINDATA] = await cleanSiteData(
@@ -607,7 +608,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_SERVICE_WORKERS) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 77) ||
+    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 77) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.SERVICEWORKERS] = await cleanSiteData(

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -555,7 +555,7 @@ export const otherBrowsingDataCleanup = async (
   const browsingDataResult: ActivityLog['browsingDataCleanup'] = {};
   if (
     getSetting(state, SettingID.CLEANUP_CACHE) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '78') ||
+    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 78) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.CACHE] = await cleanSiteData(
@@ -568,7 +568,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_INDEXEDDB) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '77') ||
+    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 77) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.INDEXEDDB] = await cleanSiteData(
@@ -581,7 +581,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_LOCALSTORAGE) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '58') ||
+    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 58) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.LOCALSTORAGE] = await cleanSiteData(
@@ -594,7 +594,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_PLUGIN_DATA) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '78') ||
+    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 78) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.PLUGINDATA] = await cleanSiteData(
@@ -607,7 +607,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_SERVICE_WORKERS) &&
-    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= '77') ||
+    ((isFirefoxNotAndroid(state.cache) && state.cache.browserVersion >= 77) ||
       chrome)
   ) {
     browsingDataResult[SiteDataType.SERVICEWORKERS] = await cleanSiteData(

--- a/src/ui/common_components/ExpressionOptions.tsx
+++ b/src/ui/common_components/ExpressionOptions.tsx
@@ -172,8 +172,8 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
                 ...expression,
                 cookieNames: checked
                   ? originalCookieNames.filter(
-                      (cookieName) => cookieName !== name,
-                    )
+                    (cookieName) => cookieName !== name,
+                  )
                   : [...originalCookieNames, name],
               });
             }}
@@ -273,33 +273,34 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
     const { cookies } = this.state;
     const { expression, state } = this.props;
     const keyCleanAllCookies = `${expression.id}-cleanAllCookies`;
+    const ffVersion = Number.parseInt(state.cache.browserVersion);
 
     const dropList = coerceBoolean(expression.cleanAllCookies);
     return (
       <div>
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= 78) ||
+            ffVersion >= 78) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.CACHE)}
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= 77) ||
+            ffVersion >= 77) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.INDEXEDDB)}
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= 58) ||
+            ffVersion >= 58) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.LOCALSTORAGE)}
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= 78) ||
+            ffVersion >= 78) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.PLUGINDATA)}
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= 77) ||
+            ffVersion >= 77) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.SERVICEWORKERS)}
         <div className={'checkbox'}>
@@ -321,7 +322,7 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
               icon={[
                 'far',
                 expression.cleanAllCookies === undefined ||
-                expression.cleanAllCookies
+                  expression.cleanAllCookies
                   ? 'check-square'
                   : 'square',
               ]}
@@ -336,8 +337,7 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
               aria-labelledby={keyCleanAllCookies}
             >
               {browser.i18n.getMessage(
-                `keepAllCookies${
-                  expression.listType === ListType.GREY ? 'Grey' : ''
+                `keepAllCookies${expression.listType === ListType.GREY ? 'Grey' : ''
                 }Text`,
               )}
             </label>

--- a/src/ui/common_components/ExpressionOptions.tsx
+++ b/src/ui/common_components/ExpressionOptions.tsx
@@ -279,27 +279,27 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
       <div>
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= '78') ||
+            state.cache.browserVersion >= 78) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.CACHE)}
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= '77') ||
+            state.cache.browserVersion >= 77) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.INDEXEDDB)}
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= '58') ||
+            state.cache.browserVersion >= 58) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.LOCALSTORAGE)}
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= '78') ||
+            state.cache.browserVersion >= 78) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.PLUGINDATA)}
         {!expression.expression.startsWith('file:') &&
           ((isFirefoxNotAndroid(state.cache) &&
-            state.cache.browserVersion >= '77') ||
+            state.cache.browserVersion >= 77) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.SERVICEWORKERS)}
         <div className={'checkbox'}>

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -4,6 +4,7 @@
       "version": "unreleased",
       "notes": [
         "Enhanced:  Additional Clean options now have small amount of spacing between them.",
+        "Fixed:  Version number comparison in Firefox is now by number instead of string, as it should have been in the beginning.",
         "Fixed:  Popup UI Buttons stacking when font size is small even though there is enough room for more than one button per row.  Now it should only stack when width is too small.  Fixes #1034."
       ]
     },

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -386,7 +386,7 @@ class Settings extends React.Component<SettingProps> {
             <div className="alert alert-warning">
               {browser.i18n.getMessage('browsingDataWarning')}
             </div>
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= '78') ||
+            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 78) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting
@@ -400,7 +400,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= '77') ||
+            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 77) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting
@@ -414,7 +414,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= '58') ||
+            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 58) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting
@@ -428,7 +428,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= '78') ||
+            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 78) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting
@@ -442,7 +442,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= '77') ||
+            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 77) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -209,6 +209,7 @@ class Settings extends React.Component<SettingProps> {
     const { cache, onResetButtonClick, onUpdateSetting, settings, style } =
       this.props;
     const { error, success } = this.state;
+    const ffVersion = Number.parseInt(cache.browserVersion);
     return (
       <div style={style}>
         <h1>{browser.i18n.getMessage('settingsText')}</h1>
@@ -386,7 +387,7 @@ class Settings extends React.Component<SettingProps> {
             <div className="alert alert-warning">
               {browser.i18n.getMessage('browsingDataWarning')}
             </div>
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 78) ||
+            {((isFirefoxNotAndroid(cache) && ffVersion >= 78) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting
@@ -400,7 +401,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 77) ||
+            {((isFirefoxNotAndroid(cache) && ffVersion >= 77) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting
@@ -414,7 +415,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 58) ||
+            {((isFirefoxNotAndroid(cache) && ffVersion >= 58) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting
@@ -428,7 +429,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 78) ||
+            {((isFirefoxNotAndroid(cache) && ffVersion >= 78) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting
@@ -442,7 +443,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && cache.browserVersion >= 77) ||
+            {((isFirefoxNotAndroid(cache) && ffVersion >= 77) ||
               isChrome(cache)) && (
               <div className="form-group">
                 <CheckboxSetting


### PR DESCRIPTION
Fixes #1329.

Version number check (primarily in Firefox) is now done by number instead of string.  This fixes the issue of '100' >= '79' being `false` instead of `true`.

🤦 ...I wonder why I didn't do this in the first place.