### PR TITLE
Fix site data being cleaned up on restart when whitelisted.  

### DIFF
--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -55,7 +55,7 @@ const sampleTab: browser.tabs.Tab = {
   windowId: 1,
 };
 
-const wildCardWhiteListGoogle: Expression = {
+const wildCardGreyListGoogle: Expression = {
   expression: '*.google.com',
   id: '1',
   listType: ListType.GREY,
@@ -150,7 +150,7 @@ const sampleState: State = {
   lists: {
     default: [
       wildCardGreyGit,
-      wildCardWhiteListGoogle,
+      wildCardGreyListGoogle,
       whiteListYoutube,
       exampleWithCookieName,
       exampleWithCookieNameCleanAllCookiesTrue,
@@ -1024,6 +1024,48 @@ describe('CleanupService', () => {
       const result = filterSiteData(cleanReasonObj, SiteDataType.CACHE);
       expect(result).toBe(true);
     });
+    it('should return true because of no matched expression on a CAD Cookie', () => {
+      const cleanReasonObj: CleanReasonObject = {
+        cached: false,
+        cleanCookie: true,
+        cookie: {
+          ...mockCookie,
+        },
+        openTabStatus: OpenTabStatus.TabsWasNotIgnored,
+        reason: ReasonClean.CADSiteDataCookie,
+      };
+      const result = filterSiteData(cleanReasonObj, SiteDataType.CACHE);
+      expect(result).toBe(true);
+    });
+    it('should return true because of no matched expression on a CAD Cookie on restart', () => {
+      const cleanReasonObj: CleanReasonObject = {
+        cached: false,
+        cleanCookie: true,
+        cookie: {
+          ...mockCookie,
+        },
+        openTabStatus: OpenTabStatus.TabsWasNotIgnored,
+        reason: ReasonClean.CADSiteDataCookieRestart,
+      };
+      const result = filterSiteData(cleanReasonObj, SiteDataType.CACHE);
+      expect(result).toBe(true);
+    });
+    it('should return true because of matched expression on a CAD Cookie on restart', () => {
+      const cleanReasonObj: CleanReasonObject = {
+        cached: false,
+        cleanCookie: true,
+        cookie: {
+          ...mockCookie,
+        },
+        expression: {
+          ...restartListCleanTest,
+        },
+        openTabStatus: OpenTabStatus.TabsWasNotIgnored,
+        reason: ReasonClean.CADSiteDataCookieRestart,
+      };
+      const result = filterSiteData(cleanReasonObj, SiteDataType.CACHE);
+      expect(result).toBe(true);
+    });
 
     it('should return false because of a matched expression but cleanLocalStorage was undefined', () => {
       const cleanReasonObj: CleanReasonObject = {
@@ -1136,6 +1178,39 @@ describe('CleanupService', () => {
         },
         openTabStatus: OpenTabStatus.TabsWasNotIgnored,
         reason: ReasonClean.StartupCleanupAndGreyList,
+      };
+      const result = filterSiteData(cleanReasonObj, SiteDataType.LOCALSTORAGE);
+      expect(result).toBe(true);
+    });
+    it('should return false because of whiteList expression with localstorage checked and is restart cleanup mode', () => {
+      const cleanReasonObj: CleanReasonObject = {
+        cached: false,
+        cleanCookie: true,
+        cookie: {
+          ...mockCookie,
+        },
+        expression: {
+          ...whiteListAllExceptTwitter,
+        },
+        openTabStatus: OpenTabStatus.TabsWasNotIgnored,
+        reason: ReasonClean.CADSiteDataCookieRestart,
+      };
+      const result = filterSiteData(cleanReasonObj, SiteDataType.LOCALSTORAGE);
+      expect(result).toBe(false);
+    });
+    it('should return true because of whiteList expression with localstorage unchecked and is restart cleanup mode', () => {
+      const cleanReasonObj: CleanReasonObject = {
+        cached: false,
+        cleanCookie: true,
+        cookie: {
+          ...mockCookie,
+        },
+        expression: {
+          ...whiteListAllExceptTwitter,
+          cleanSiteData: [SiteDataType.LOCALSTORAGE],
+        },
+        openTabStatus: OpenTabStatus.TabsWasNotIgnored,
+        reason: ReasonClean.CADSiteDataCookieRestart,
       };
       const result = filterSiteData(cleanReasonObj, SiteDataType.LOCALSTORAGE);
       expect(result).toBe(true);

--- a/__tests__/services/SettingService.spec.ts
+++ b/__tests__/services/SettingService.spec.ts
@@ -156,6 +156,13 @@ describe('SettingService', () => {
       await SettingService.onSettingsChange();
       expect(global.browser.browsingData.remove).toHaveBeenCalledTimes(1);
     });
+    it('should NOT clean that site data if it was recently enabled and clean site data on enable is false', async () => {
+      TestStore.changeSetting(SettingID.SITEDATA_EMPTY_ON_ENABLE, false);
+      await SettingService.onSettingsChange();
+      TestStore.changeSetting(SettingID.CLEANUP_CACHE, true);
+      await SettingService.onSettingsChange();
+      expect(global.browser.browsingData.remove).not.toHaveBeenCalled();
+    });
     it('should enable global icon if active mode was recently enabled', async () => {
       TestStore.changeSetting(SettingID.ACTIVE_MODE, true);
       await SettingService.onSettingsChange();

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -59,6 +59,10 @@
     "message": "Auto-clean enabled",
     "description": "Auto-clean enabled"
   },
+  "browsingDataNoEmptyWarning": {
+    "message": "WARNING:  Existing site data types will NOT be cleaned when newly enabled. We will NOT be able to clean any of the existing data until its domain has been visited at least once, including from unwanted domains.",
+    "description": "WARNING:  Existing site data types will NOT be cleaned when newly enabled. We will NOT be able to clean any of the existing data until its domain has been visited at least once, including from unwanted domains. Found in CAD Settings"
+  },
   "browsingDataWarning": {
     "message": "WARNING: Upon enabling any of the following site data cleanup options, ALL existing data for that type will be cleared.",
     "description": "WARNING: Upon enabling any of the following site data cleanup options, ALL existing data for that type will be cleared. Found in CAD Settings"
@@ -1034,6 +1038,10 @@
   "showNumberOfCookiesInIconText": {
     "message": "Show Number of Cookies for that Domain over the Icon",
     "description": "Show Number of Cookies for that Domain over the Icon"
+  },
+  "siteDataEmptyOnEnable": {
+    "message": "Clean Existing Data for Newly Enabled Browsing Data Types",
+    "description": "Clean Existing Data for Newly Enabled Browsing Data Types"
   },
   "siteDataText": {
     "message": "Site Data",

--- a/src/redux/State.ts
+++ b/src/redux/State.ts
@@ -116,6 +116,10 @@ export const initialState: State = {
       name: SettingID.NUM_COOKIES_ICON,
       value: true,
     },
+    [SettingID.SITEDATA_EMPTY_ON_ENABLE]: {
+      name: SettingID.SITEDATA_EMPTY_ON_ENABLE,
+      value: true,
+    },
     [SettingID.SIZE_POPUP]: {
       name: SettingID.SIZE_POPUP,
       value: 16,

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -684,14 +684,20 @@ export const filterSiteData = (
   const notInAnyLists =
     obj.reason === ReasonClean.NoMatchedExpression ||
     obj.reason === ReasonClean.StartupNoMatchedExpression;
+  const isCADCookieNoExpression =
+    (obj.reason === ReasonClean.CADSiteDataCookie ||
+      ReasonClean.CADSiteDataCookieRestart) &&
+    obj.expression === undefined;
   const nonBlankCookieHostName = obj.cookie.hostname.trim() !== '';
   const cleanSiteDataInExpression = parseCleanSiteData(
     obj.expression?.cleanSiteData?.includes(siteData),
   );
   const isRestartCleanup =
-    obj.reason === ReasonClean.CADSiteDataCookieRestart ||
+    (obj.reason === ReasonClean.CADSiteDataCookieRestart &&
+      obj.expression?.listType === ListType.GREY) ||
     obj.reason === ReasonClean.StartupCleanupAndGreyList;
-  const canCleanSiteData = cleanSiteDataInExpression || isRestartCleanup;
+  const canCleanSiteData =
+    isCADCookieNoExpression || cleanSiteDataInExpression || isRestartCleanup;
   const cro: CleanReasonObject = {
     ...obj,
     cookie: {
@@ -706,6 +712,7 @@ export const filterSiteData = (
         notProtectedByOpenTab,
         notInAnyLists,
         siteData,
+        isCADCookieNoExpression,
         cleanSiteDataInExpression,
         isRestartCleanup,
         canCleanSiteData,

--- a/src/services/SettingService.ts
+++ b/src/services/SettingService.ts
@@ -57,6 +57,16 @@ export default class SettingService extends StoreUser {
         ) {
           continue;
         }
+        if (SettingService.getCurrent(SettingID.SITEDATA_EMPTY_ON_ENABLE) === false) {
+          cadLog(
+            {
+              msg: `${siteData} setting activated, but Empty Site Data on Enable is false. Existing site data kept.`,
+              type: 'info',
+            },
+            SettingService.getCurrent(SettingID.DEBUG_MODE) as boolean,
+          )
+          continue;
+        }
         await browser.browsingData.remove(
           { since: 0 },
           { [siteDataToBrowser(siteData)]: true },

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -105,6 +105,7 @@ declare const enum SettingID {
   NUM_COOKIES_ICON = 'showNumOfCookiesInIcon',
   OLD_GREY_CLEAN_LOCALSTORAGE = 'greyCleanLocalstorage',
   OLD_WHITE_CLEAN_LOCALSTORAGE = 'whiteCleanLocalstorage',
+  SITEDATA_EMPTY_ON_ENABLE = 'siteDataEmptyOnEnable',
   SIZE_POPUP = 'sizePopup',
   SIZE_SETTING = 'sizeSetting',
   STAT_LOGGING = 'statLogging',

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,13 @@
 {
   "releases": [
     {
+      "version": "3.8.0 - alpha",
+      "notes": [
+        "Added:  Option to keep or clean existing site data on new enables.",
+        "Fixed:  Site Data being cleaned up despite a whitelist entry on restart. Closes #1395 via PR #1397"
+      ]
+    },
+    {
       "version": "3.7.0",
       "notes": [
         "Enhanced:  Additional Clean options now have small amount of spacing between them.",

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -170,11 +170,13 @@ class Settings extends React.Component<SettingProps> {
           error: '',
           success: browser.i18n.getMessage('importCoreSettingsText'),
         });
-      } catch (error) {
-        this.setState({
-          error: error.toString(),
-          success: '',
-        });
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          this.setState({
+            error: error.toString(),
+            success: '',
+          });
+        }
       }
     };
 
@@ -384,8 +386,33 @@ class Settings extends React.Component<SettingProps> {
             <legend>
               {browser.i18n.getMessage('settingGroupOtherBrowsing')}
             </legend>
-            <div className="alert alert-warning">
-              {browser.i18n.getMessage('browsingDataWarning')}
+            <div className="form-group">
+              <CheckboxSetting
+                text={browser.i18n.getMessage('siteDataEmptyOnEnable')}
+                settingObject={settings[SettingID.SITEDATA_EMPTY_ON_ENABLE]}
+                inline={true}
+                updateSetting={(payload) => onUpdateSetting(payload)}
+              />
+              <SettingsTooltip
+                hrefURL={
+                  '#clean-existing-data-for-newly-enabled-browsing-data-types'
+                }
+              />
+            </div>
+            <div
+              className={`alert alert-${
+                settings[SettingID.SITEDATA_EMPTY_ON_ENABLE].value === true
+                  ? 'warning'
+                  : 'danger'
+              }`}
+            >
+              {browser.i18n.getMessage(
+                `browsingData${
+                  settings[SettingID.SITEDATA_EMPTY_ON_ENABLE].value === true
+                    ? ''
+                    : 'NoEmpty'
+                }Warning`,
+              )}
             </div>
             {((isFirefoxNotAndroid(cache) && ffVersion >= 78) ||
               isChrome(cache)) && (


### PR DESCRIPTION
Fixes #1395.
Added new option to keep existing data on site data enable.  New warning when this option is disabled.  Default is enabled (keeps existing workflow of clean state on enable).

![image](https://user-images.githubusercontent.com/6724477/170813631-8b6903a6-3f4f-4e50-a47b-519306e7963f.png)

![image](https://user-images.githubusercontent.com/6724477/170813656-c758680a-626e-4f58-8590-83430a4fe3fe.png)



Signed-off-by: Kenneth T <6724477+kennethtran93@users.noreply.github.com>