### PR TITLE
Trigger special localstorage clean function on 'All' manual cleanup

### DIFF
--- a/src/ui/popup/components/CleanDataButton.tsx
+++ b/src/ui/popup/components/CleanDataButton.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import {
   clearCookiesForThisDomain,
+  clearLocalStorageForThisDomain,
   clearSiteDataForThisDomain,
 } from '../../../services/CleanupService';
 import { animateFlash } from '../popupLib';
@@ -43,8 +44,12 @@ const cleanSiteDataUI = async (
   let result = await clearSiteDataForThisDomain(state, siteData, hostname);
   if (siteData === 'All') {
     if (!tab) return false;
-    const success = await clearCookiesForThisDomain(state, tab);
-    result = result || success;
+    const cookieSuccess = await clearCookiesForThisDomain(state, tab);
+    const localStorageSuccess = await clearLocalStorageForThisDomain(
+      state,
+      tab,
+    );
+    result = result || cookieSuccess || localStorageSuccess;
   }
   return result;
 };

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -4,7 +4,8 @@
       "version": "3.8.0 - alpha",
       "notes": [
         "Added:  Option to keep or clean existing site data on new enables.",
-        "Fixed:  Site Data being cleaned up despite a whitelist entry on restart. Closes #1395 via PR #1397"
+        "Fixed:  Site Data being cleaned up despite a whitelist entry on restart. Closes #1395 via PR #1397",
+        "Fixed:  SessionStorage data in Firefox wasn't being cleaned when manual clean 'All' was triggered.  Closes #1402 via PR#1404"
       ]
     },
     {


### PR DESCRIPTION
Fixes #1402.

This executes the clean localstorage function created to include sessionstorage cleanup.  While Chrome does clean up session storage via browsingdata API when localstorage is passed in (at least that's what it looks like on testing), Firefox does not.

Doing this will double-clean the localstorage for that domain, but at least we make sure session storage is also cleaned up (especially on Firefox).

Signed-off-by: Kenneth T <6724477+kennethtran93@users.noreply.github.com>