### PR TITLE
Initial Test of browser type detection for Firefox

### DIFF
--- a/extension/global_files/browserDetect.js
+++ b/extension/global_files/browserDetect.js
@@ -19,8 +19,8 @@ var browserDetect = function () {
     !!window.opera ||
     navigator.userAgent.indexOf(' OPR/') >= 0;
 
-  // Firefox 1.0+
-  var isFirefox = typeof InstallTrigger !== 'undefined';
+  // Firefox 1.0+ (InstallTrigger only available up to FF102.  Webextension API browser.contextualIdentities still only available in Firefox/Firefox Android so use that for now.)
+  var isFirefox = typeof InstallTrigger !== 'undefined' || typeof browser.contextualIdentities !== 'undefined';
 
   // Safari 3.0+ "[object HTMLElementConstructor]"
   var isSafari =

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,12 @@
 {
   "releases": [
     {
+      "version": "3.8.1 - unreleased",
+      "notes": [
+        "Fixed:  Browser detection in Firefox 103+ as the previous browser feature has been deprecated and removed. Fixes #1409 via PR #1410."
+      ]
+    },
+    {
       "version": "3.8.0",
       "notes": [
         "Added:  Option to keep or clean existing site data on new enables.",


### PR DESCRIPTION
In the recent versions of Firefox, the existing function/method/object that we have been using to detect if the browser was Firefox has been deprecated and would be removed starting in 103.  This should be a sufficient patch fix for now until other browsers actually implement `browser.contextualIdentities`.

If anybody else know of another (possibly better) way of determining if the browser was Firefox (and Firefox Android) or not, do let me know (including the method).  Checking the User-Agent string (or any functions/libraries that would ultimately rely on this) is NOT one of them as these can be spoofed/changed by the user.

Fixes #1409.

Signed-off-by: Kenneth T <6724477+kennethtran93@users.noreply.github.com>