### PR TITLE
Fix passing IP Addresses into browsingData removal functions

### DIFF
--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -1324,6 +1324,30 @@ describe('Library Functions', () => {
         'https://.www.example.com',
       ]);
     });
+
+    it('should return proper IPv4 address', () => {
+      expect(prepareCleanupDomains('127.0.0.1', browserName.Firefox)).toEqual([
+        '127.0.0.1',
+      ]);
+    });
+
+    it('should return proper IPv4 address for Chrome', () => {
+      expect(prepareCleanupDomains('127.0.0.1', browserName.Chrome)).toEqual([
+        'http://127.0.0.1',
+        'https://127.0.0.1',
+      ]);
+    });
+    it('should return proper IPv6 address', () => {
+      expect(prepareCleanupDomains('::1', browserName.Firefox)).toEqual([
+        '[::1]',
+      ]);
+    });
+    it('should return proper IPv6 address for Chrome', () => {
+      expect(prepareCleanupDomains('::1', browserName.Chrome)).toEqual([
+        'http://[::1]',
+        'https://[::1]',
+      ]);
+    });
   });
 
   describe('prepareCookieDomain()', () => {
@@ -1336,6 +1360,17 @@ describe('Library Functions', () => {
           secure: true,
         }),
       ).toEqual('https://google.com/');
+    });
+
+    it('should return an IPv4 Address if domain was an IPv4 address', () => {
+      expect(
+        prepareCookieDomain({
+          ...mockCookie,
+          domain: '127.0.0.1',
+          path: '/',
+          secure: true,
+        }),
+      ).toEqual('https://127.0.0.1/');
     });
 
     it('should return a wrapped ivp6 ip cookie domain in brackets', () => {

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -3,6 +3,7 @@
     {
       "version": "3.8.2",
       "notes": [
+        "Fixed:  Passing IP Addresses to browsingData / site data cleanups. Fixes #983 via PR#, with thanks to Rob W.",
         "Fixed:  Removing expired cookies now respect configured domain cleanup rules. Fixes #1427 via PR#1450.",
         "Updated:  Translations from Crowdin."
       ]

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -3,7 +3,7 @@
     {
       "version": "3.8.2",
       "notes": [
-        "Fixed:  Passing IP Addresses to browsingData / site data cleanups. Fixes #983 via PR#, with thanks to Rob W.",
+        "Fixed:  Passing IP Addresses to browsingData / site data cleanups. Fixes #983 via PR#1451, with thanks to Rob W.",
         "Fixed:  Removing expired cookies now respect configured domain cleanup rules. Fixes #1427 via PR#1450.",
         "Updated:  Translations from Crowdin."
       ]


### PR DESCRIPTION
Fixes #983 (though I haven't tested IPv6 cleanups yet).
Signed-off-by: Kenneth T <6724477+kennethtran93@users.noreply.github.com>