### PR TITLE
Switch to @types/firefox-webext-browser

### DIFF
--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -50,7 +50,6 @@ const sampleTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://example.com',
   windowId: 1,
 };
@@ -168,6 +167,7 @@ const sampleState: State = {
 
 const mockCookie: CookiePropertiesCleanup = {
   domain: 'test.com',
+  firstPartyDomain: '',
   hostOnly: true,
   hostname: 'test.com',
   httpOnly: true,
@@ -946,7 +946,7 @@ describe('CleanupService', () => {
   describe('clearLocalStorageForThisDomain()', () => {
     it('should clear localstorage from active tab (via tabs.executeScript)', async () => {
       when(global.browser.tabs.executeScript)
-        .calledWith(undefined, expect.any(Object))
+        .calledWith(expect.any(Object))
         .mockResolvedValue([{ local: 2, session: 0 }] as never);
       expect(
         await clearLocalStorageForThisDomain(initialState, sampleTab),
@@ -956,7 +956,7 @@ describe('CleanupService', () => {
     });
     it('should show error notification if browser.tabs.executeScript threw an error', async () => {
       when(global.browser.tabs.executeScript)
-        .calledWith(undefined, expect.any(Object))
+        .calledWith(expect.any(Object))
         .mockRejectedValue(new Error('test') as never);
       expect(
         await clearLocalStorageForThisDomain(initialState, sampleTab),
@@ -967,7 +967,7 @@ describe('CleanupService', () => {
     });
     it('should only show the no cleanup done notification if browser.tabs.executeScript threw a non-error type', async () => {
       when(global.browser.tabs.executeScript)
-        .calledWith(undefined, expect.any(Object))
+        .calledWith(expect.any(Object))
         .mockRejectedValue('error' as never);
       expect(
         await clearLocalStorageForThisDomain(initialState, sampleTab),

--- a/__tests__/services/ContextMenuEvents.spec.ts
+++ b/__tests__/services/ContextMenuEvents.spec.ts
@@ -81,7 +81,6 @@ const sampleTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://www.example.com',
   windowId: 1,
 };

--- a/__tests__/services/ContextualIdentitiesEvents.spec.ts
+++ b/__tests__/services/ContextualIdentitiesEvents.spec.ts
@@ -83,7 +83,9 @@ const defaultContextualIdentity: browser.contextualIdentities.ContextualIdentity
   {
     cookieStoreId: 'firefox-container-0',
     color: 'blue',
+    colorCode: '#37adff',
     icon: 'fingerprint',
+    iconUrl: 'resource://usercontext-content/fingerprint.svg',
     name: 'Testing Container',
   };
 

--- a/__tests__/services/CookieEvents.spec.ts
+++ b/__tests__/services/CookieEvents.spec.ts
@@ -22,6 +22,7 @@ const spyLib: JestSpyObject = global.generateSpies(Lib);
 
 const defaultCookie: browser.cookies.Cookie = {
   domain: 'domain.com',
+  firstPartyDomain: '',
   hostOnly: false,
   httpOnly: false,
   name: 'CookieName',
@@ -45,7 +46,6 @@ const defaultTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://domain.com',
   windowId: 1,
 };

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -53,6 +53,7 @@ import ipaddr from 'ipaddr.js';
 
 const mockCookie: browser.cookies.Cookie = {
   domain: 'domain.com',
+  firstPartyDomain: '',
   hostOnly: true,
   httpOnly: true,
   name: 'blah',
@@ -488,6 +489,7 @@ describe('Library Functions', () => {
 
     const testCookie: browser.cookies.Cookie = {
       domain: 'domain.com',
+      firstPartyDomain: '',
       hostOnly: true,
       httpOnly: true,
       name: 'blah',
@@ -511,7 +513,6 @@ describe('Library Functions', () => {
       isInReaderMode: false,
       lastAccessed: 12345678,
       pinned: false,
-      selected: true,
       url: 'https://www.example.com',
       windowId: 1,
     };
@@ -1446,7 +1447,7 @@ describe('Library Functions', () => {
   });
 
   describe('returnOptionalCookieAPIAttributes()', () => {
-    it('should return an object with an undefined firstPartyDomain if browser was Firefox and firstPartyDomain was not already defined.', () => {
+    it('should return an object with an empty firstPartyDomain if browser was Firefox and firstPartyDomain was not already defined.', () => {
       const state = {
         ...initialState,
         cache: {
@@ -1464,7 +1465,7 @@ describe('Library Functions', () => {
       expect(results).toEqual(
         expect.objectContaining({
           domain: 'example.com',
-          firstPartyDomain: undefined,
+          firstPartyDomain: '',
         }),
       );
     });

--- a/__tests__/services/SettingService.spec.ts
+++ b/__tests__/services/SettingService.spec.ts
@@ -85,7 +85,6 @@ const defaultTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://domain.com',
   windowId: 1,
 };

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -90,7 +90,6 @@ const sampleTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://www.example.com',
   windowId: 1,
 };
@@ -127,6 +126,7 @@ describe('TabEvents', () => {
 
     const testCookie: browser.cookies.Cookie = {
       domain: 'domain.com',
+      firstPartyDomain: '',
       hostOnly: true,
       httpOnly: true,
       name: 'blah',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "webextension-polyfill": "^0.8.0"
       },
       "devDependencies": {
+        "@types/firefox-webext-browser": "^120.0.0",
         "@types/jest": "^26.0.24",
         "@types/jest-when": "^3.5.2",
         "@types/react": "^17.0.52",
@@ -51,7 +52,6 @@
         "ts-jest": "^26.5.6",
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.4",
-        "web-ext-types": "^3.2.1",
         "webpack": "^5.75.0",
         "webpack-bundle-analyzer": "^4.7.0",
         "webpack-cli": "^4.10.0"
@@ -2939,6 +2939,12 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
+    },
+    "node_modules/@types/firefox-webext-browser": {
+      "version": "120.0.0",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-120.0.0.tgz",
+      "integrity": "sha512-L+tDlwNeq0kQGfAYc2sNfKhRWJz9CNRvlbq9HnLibKUiJ3VTThG8sj7xrJF4CtKpEA9eBAr91Z2nnKIAy+xUJg==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -14938,12 +14944,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/web-ext-types": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-ext-types/-/web-ext-types-3.2.1.tgz",
-      "integrity": "sha512-oQZYDU3W8X867h8Jmt3129kRVKklz70db40Y6OzoTTuzOJpF/dB2KULJUf0txVPyUUXuyzV8GmT3nVvRHoG+Ew==",
-      "dev": true
-    },
     "node_modules/webextension-polyfill": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
@@ -17976,6 +17976,12 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
+    },
+    "@types/firefox-webext-browser": {
+      "version": "120.0.0",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-120.0.0.tgz",
+      "integrity": "sha512-L+tDlwNeq0kQGfAYc2sNfKhRWJz9CNRvlbq9HnLibKUiJ3VTThG8sj7xrJF4CtKpEA9eBAr91Z2nnKIAy+xUJg==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -27416,12 +27422,6 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
-    },
-    "web-ext-types": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-ext-types/-/web-ext-types-3.2.1.tgz",
-      "integrity": "sha512-oQZYDU3W8X867h8Jmt3129kRVKklz70db40Y6OzoTTuzOJpF/dB2KULJUf0txVPyUUXuyzV8GmT3nVvRHoG+Ew==",
-      "dev": true
     },
     "webextension-polyfill": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "webextension-polyfill": "^0.8.0"
   },
   "devDependencies": {
+    "@types/firefox-webext-browser": "^120.0.0",
     "@types/jest": "^26.0.24",
     "@types/jest-when": "^3.5.2",
     "@types/react": "^17.0.52",
@@ -57,7 +58,6 @@
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.4.2",
     "typescript": "^4.9.4",
-    "web-ext-types": "^3.2.1",
     "webpack": "^5.75.0",
     "webpack-bundle-analyzer": "^4.7.0",
     "webpack-cli": "^4.10.0"

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -295,7 +295,7 @@ export const cleanCookies = async (
   state: State,
   markedForDeletion: CleanReasonObject[],
 ): Promise<void> => {
-  const promiseArr: Promise<browser.cookies.Cookie | null>[] = [];
+  const promiseArr: Promise<browser.cookies._RemoveReturnDetails | null>[] = [];
   markedForDeletion.forEach((obj) => {
     const cookieProperties = obj.cookie;
     const cookieAPIProperties = returnOptionalCookieAPIAttributes(state, {
@@ -399,7 +399,7 @@ export const clearLocalStorageForThisDomain = async (
   try {
     let local = 0;
     let session = 0;
-    const result = await browser.tabs.executeScript(undefined, {
+    const result = await browser.tabs.executeScript({
       code: `var cad_r = {local: window.localStorage.length, session: window.sessionStorage.length};window.localStorage.clear();window.sessionStorage.clear();cad_r;`,
     });
     result.forEach((frame: { [key: string]: any }) => {

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -111,7 +111,7 @@ export const convertVersionToNumber = (version?: string): number => {
  * @param action The EventListenerAction (add/remove).
  */
 export const eventListenerActions = (
-  event: EvListener<any>,
+  event: WebExtEvent<any>,
   listener: (...args: any[]) => void,
   action: EventListenerAction,
 ): void => {

--- a/src/typings/Cleanup.d.ts
+++ b/src/typings/Cleanup.d.ts
@@ -62,7 +62,7 @@ interface CleanReasonObject {
   cookie: CookiePropertiesCleanup;
 }
 
-interface CookiePropertiesCleanup extends browser.cookies.CookieProperties {
+interface CookiePropertiesCleanup extends browser.cookies.Cookie {
   mainDomain: string;
   hostname: string;
   preparedCookieDomain: string;

--- a/src/typings/Webext.d.ts
+++ b/src/typings/Webext.d.ts
@@ -32,10 +32,7 @@ declare namespace browser.browsingData {
 }
 
 declare namespace browser.cookies {
-  interface CookieProperties extends browser.cookies.Cookie {
-    firstPartyDomain?: string;
-  }
-  type OptionalCookieProperties = Partial<CookieProperties>;
+  type OptionalCookieProperties = Partial<Cookie>;
 }
 
 // Until web-ext-types land this, per https://github.com/kelseasy/web-ext-types/issues/81#issuecomment-527758881

--- a/src/ui/common_components/ExpressionOptions.tsx
+++ b/src/ui/common_components/ExpressionOptions.tsx
@@ -34,7 +34,7 @@ interface OwnProps {
 }
 
 class InitialState {
-  public cookies: browser.cookies.CookieProperties[] = [];
+  public cookies: browser.cookies.Cookie[] = [];
 }
 
 type ExpressionOptionsProps = OwnProps & DispatchProps & StateProps;
@@ -83,7 +83,7 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
   public async getAllCookies() {
     const { expression } = this.props;
     const exp = expression.expression;
-    let cookies: browser.cookies.CookieProperties[] = [];
+    let cookies: browser.cookies.Cookie[] = [];
     if (exp.startsWith('/') && exp.endsWith('/')) {
       // Treat expression as regular expression.  Get all cookies then regex domain.
       const allCookies = await browser.cookies.getAll(
@@ -148,7 +148,7 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
   }
 
   public createCookieList(
-    cookies: browser.cookies.CookieProperties[],
+    cookies: browser.cookies.Cookie[],
     expression: Expression,
   ) {
     const { onUpdateExpression } = this.props;

--- a/src/ui/settings/App.tsx
+++ b/src/ui/settings/App.tsx
@@ -37,6 +37,7 @@ class App extends Component<OwnProps> {
       (this.props.sizeSetting as number) || 16
     }px`;
     const tab = await browser.tabs.getCurrent();
+    if (tab === undefined) return;
     const tabURL = new URL(tab.url || '');
     this.setState({
       activeTab:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,6 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": [
       "node_modules/@types",
-      "node_modules/web-ext-types",
       "src/typings"
     ] /* List of folders to include type definitions from. */,
     // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
[web-ext-types](https://www.npmjs.com/package/web-ext-types) has not been updated for 5 years and omits many modern changes to the APIs, like Cookie.partitionKey for #807.

Javascript isn't a first language, so reviews appreciated.